### PR TITLE
Mobile auth contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ yarn-error.log*
 # Misc
 .DS_Store
 *.pem
+
+# Local planning artifacts
+docs/mvp-sprints/
+scripts/generate-mvp-sprint-backlogs.mjs
+scripts/import-sprint-issues-to-gh.mjs

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,12 +1,14 @@
-import { Stack, router, usePathname } from "expo-router";
+import { Stack, router, useSegments } from "expo-router";
 import { useEffect } from "react";
 import { initializeApiClient, shutdownApiClient } from "@/src/network/apiClient";
 import { Button, StyleSheet, Text, View } from "react-native";
 import { useSessionBootstrap } from "@/src/auth/useSessionBootstrap";
 
+const AUTH_ROUTES = new Set(["login", "register"]);
+
 export default function RootLayout() {
   const { state, message, retry } = useSessionBootstrap();
-  const pathname = usePathname();
+  const segments = useSegments();
 
   useEffect(() => {
     void initializeApiClient();
@@ -20,7 +22,8 @@ export default function RootLayout() {
       return;
     }
 
-    const isAuthRoute = pathname === "/login" || pathname === "/register";
+    const activeRoute = segments[0];
+    const isAuthRoute = typeof activeRoute === "string" && AUTH_ROUTES.has(activeRoute);
 
     if (state === "unauthenticated" && !isAuthRoute) {
       router.replace("/login");
@@ -30,7 +33,7 @@ export default function RootLayout() {
     if (state === "authenticated" && isAuthRoute) {
       router.replace("/");
     }
-  }, [pathname, state]);
+  }, [segments, state]);
 
   if (state === "loading") {
     return (
@@ -55,6 +58,7 @@ export default function RootLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
+      <Stack.Screen name="profile" />
       <Stack.Screen name="login" />
       <Stack.Screen name="register" />
     </Stack>

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Button, Linking, StyleSheet, Text, View, useColorScheme } from "react-native";
-import { Link } from "expo-router";
 import { Button, Linking, Pressable, StyleSheet, Text, View, useColorScheme } from "react-native";
 import { router } from "expo-router";
 import MapView, { Marker, Region } from "react-native-maps";
@@ -15,25 +13,6 @@ import { apiClient } from "@/src/network/apiClient";
 import type { LocationDetailsResponse } from "@/src/network/contracts";
 import { LocationBottomSheet, LocationSheetDetails } from "@/src/map/LocationBottomSheet";
 import { logoutSession } from "@/src/auth/authClient";
-
-type LocationDetailsResponse = {
-  data?: {
-    item?: {
-      _id?: string;
-      name?: string;
-      type?: string;
-      address?: string;
-      status?: string;
-      queueSnapshot?: {
-        level?: string;
-        estimatedWaitMinutes?: number;
-        confidence?: number;
-        lastUpdatedAt?: string | null;
-        isStale?: boolean;
-      };
-    };
-  };
-};
 
 export default function Index() {
   const colorScheme = useColorScheme();
@@ -334,12 +313,6 @@ const styles = StyleSheet.create({
   text: {
     color: "#dce3ea",
     fontSize: 12,
-  },
-  profileLink: {
-    color: "#9fe3ff",
-    fontSize: 13,
-    fontWeight: "700",
-    marginTop: 10,
   },
   modal: {
     position: "absolute",

--- a/apps/mobile/app/profile.tsx
+++ b/apps/mobile/app/profile.tsx
@@ -3,21 +3,7 @@ import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { router } from "expo-router";
 import { apiClient } from "@/src/network/apiClient";
 import { clearStoredSessionTokens, getStoredSessionTokens } from "@/src/auth/secureTokens";
-
-type ProfilePayload = {
-  data?: {
-    user?: {
-      id?: string;
-      email?: string;
-      role?: string;
-    } | null;
-    contributionSummary?: {
-      reportCount?: number;
-      activeSessions?: number;
-      rewardBalance?: number;
-    };
-  };
-};
+import type { ProfileResponse } from "@/src/network/contracts";
 
 export default function ProfileScreen() {
   const [state, setState] = useState({
@@ -54,7 +40,7 @@ export default function ProfileScreen() {
           },
         });
 
-        const payload = response.data as ProfilePayload;
+        const payload = response.data as ProfileResponse;
         if (cancelled) {
           return;
         }
@@ -215,4 +201,3 @@ const styles = StyleSheet.create({
     fontWeight: "800",
   },
 });
-

--- a/apps/mobile/src/auth/authClient.ts
+++ b/apps/mobile/src/auth/authClient.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { clearStoredSessionTokens, saveSessionTokens } from "./secureTokens";
 import { useSessionStore } from "./sessionStore";
+import type { AuthSessionResponse } from "@/src/network/contracts";
 
 const apiBaseUrl = process.env.EXPO_PUBLIC_API_URL;
 if (!apiBaseUrl) {
@@ -11,14 +12,6 @@ const client = axios.create({
   baseURL: apiBaseUrl,
   timeout: 10000,
 });
-
-type AuthResponsePayload = {
-  data?: {
-    accessToken?: string;
-    refreshToken?: string;
-    deviceId?: string;
-  };
-};
 
 export const registerWithEmail = async (email: string, password: string) => {
   await client.post("/auth/register", { email, password });
@@ -35,7 +28,7 @@ export const loginWithEmail = async (params: {
     deviceId: params.deviceId,
   });
 
-  const payload = response.data as AuthResponsePayload;
+  const payload = response.data as AuthSessionResponse;
   const accessToken = payload.data?.accessToken;
   const refreshToken = payload.data?.refreshToken;
   const deviceId = payload.data?.deviceId || params.deviceId;
@@ -65,4 +58,3 @@ export const logoutSession = async () => {
     deviceId: null,
   });
 };
-

--- a/apps/mobile/src/auth/sessionBootstrap.ts
+++ b/apps/mobile/src/auth/sessionBootstrap.ts
@@ -5,6 +5,7 @@ import {
   getStoredSessionTokens,
   saveSessionTokens,
 } from "./secureTokens";
+import type { AuthSessionResponse } from "@/src/network/contracts";
 
 type BootstrapState = "loading" | "authenticated" | "unauthenticated" | "locked";
 
@@ -49,11 +50,7 @@ export const bootstrapSession = async (): Promise<SessionBootstrapResult> => {
       refreshToken: stored.refreshToken,
     });
 
-    const data = response.data?.data as {
-      accessToken?: string;
-      refreshToken?: string;
-      deviceId?: string;
-    };
+    const data = (response.data as AuthSessionResponse).data;
 
     if (!data?.accessToken || !data?.refreshToken) {
       throw new Error("Malformed refresh response");

--- a/apps/mobile/src/network/contracts.ts
+++ b/apps/mobile/src/network/contracts.ts
@@ -1,17 +1,23 @@
-import type { ApiResponse, NearbyLocationItem, QueueSnapshot } from "@qyou/types";
+import type {
+  ApiResponse,
+  ContributionSummary,
+  LocationDetailsItem,
+  NearbyLocationItem,
+  SessionTokens,
+  UserPublic,
+} from "@qyou/types";
 
 export type LocationDetailsResponse = ApiResponse<{
-  item?: {
-    _id?: string;
-    name?: string;
-    type?: string;
-    address?: string;
-    status?: string;
-    queueSnapshot?: QueueSnapshot;
-  };
+  item?: LocationDetailsItem;
 }>;
 
 export type NearbyLocationsResponse = ApiResponse<{
   items?: NearbyLocationItem[];
 }>;
 
+export type AuthSessionResponse = ApiResponse<SessionTokens>;
+
+export type ProfileResponse = ApiResponse<{
+  user: UserPublic | null;
+  contributionSummary: ContributionSummary;
+}>;

--- a/apps/mobile/src/polling/useBoundingBoxPolling.ts
+++ b/apps/mobile/src/polling/useBoundingBoxPolling.ts
@@ -3,26 +3,10 @@ import { useMapViewportStore } from "../store/mapViewportStore";
 import { useLocationsStore } from "../store/locationsStore";
 import { getAreaKey, getBoundingBoxCenter, getBoundingRadiusMeters, distanceInMeters } from "../map/geo";
 import { apiClient } from "../network/apiClient";
+import type { NearbyLocationsResponse } from "../network/contracts";
 
 const MIN_MOVEMENT_METERS = 500;
 const POLL_INTERVAL_MS = 12000;
-
-type NearbyResponseItem = {
-  _id: string;
-  name: string;
-  type: string;
-  address: string;
-  distanceFromUser: number;
-  location: {
-    coordinates: [number, number];
-  };
-};
-
-type NearbyResponse = {
-  data?: {
-    items?: NearbyResponseItem[];
-  };
-};
 
 export const useBoundingBoxPolling = () => {
   const boundingBox = useMapViewportStore((state) => state.boundingBox);
@@ -72,7 +56,7 @@ export const useBoundingBoxPolling = () => {
           },
         });
 
-        const payload = response.data as NearbyResponse;
+        const payload = response.data as NearbyLocationsResponse;
         const items = payload.data?.items || [];
         const normalized = items
           .filter((item) => {

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -81,8 +81,37 @@ export type QueueSnapshot = {
   estimatedWaitMinutes?: number;
   reportCount: number;
   confidence: number; // 0..1
-  lastUpdatedAt: string; // ISO
+  lastUpdatedAt: string | null; // ISO
   isStale: boolean;
+};
+
+export type NearbyLocationItem = {
+  _id: string;
+  name: string;
+  type: LocationType;
+  address: string;
+  status: LocationStatus;
+  location: GeoPoint;
+  distanceFromUser: number;
+  queueSnapshot?: QueueSnapshot;
+};
+
+export type LocationDetailsItem = {
+  _id: string;
+  name: string;
+  type: LocationType;
+  address: string;
+  status: LocationStatus;
+  location: GeoPoint;
+  queueSnapshot?: QueueSnapshot;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type ContributionSummary = {
+  reportCount: number;
+  activeSessions: number;
+  rewardBalance: number;
 };
 
 export type RewardTransactionType = 'EARN' | 'SPEND' | 'CLAIM';
@@ -105,4 +134,3 @@ export type RewardBalance = {
   lifetimeEarned?: number;
   lastUpdatedAt?: string;
 };
-


### PR DESCRIPTION
- clean up the mobile entry screen by removing duplicate imports and local shadow types
- harden Expo Router auth gating for protected screens and auth-only routes
- normalize mobile API response types against shared `@qyou/types` models
- update auth, profile, and nearby polling consumers to use the shared contract layer

closes #164 
closes #165 
closes #166 
closes #167 