### PR TITLE
Offline mob

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack, router, useSegments } from "expo-router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { initializeApiClient, shutdownApiClient } from "@/src/network/apiClient";
 import { Button, StyleSheet, Text, View } from "react-native";
 import { useSessionBootstrap } from "@/src/auth/useSessionBootstrap";
@@ -9,13 +9,34 @@ const AUTH_ROUTES = new Set(["login", "register"]);
 export default function RootLayout() {
   const { state, message, retry } = useSessionBootstrap();
   const segments = useSegments();
+  const [apiState, setApiState] = useState<"loading" | "ready" | "error">("loading");
+  const [apiMessage, setApiMessage] = useState("Preparing offline queue and network client...");
+  const [initAttempt, setInitAttempt] = useState(0);
 
   useEffect(() => {
-    void initializeApiClient();
+    let cancelled = false;
+
+    void initializeApiClient()
+      .then(() => {
+        if (cancelled) {
+          return;
+        }
+        setApiState("ready");
+        setApiMessage("Network client ready.");
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+        setApiState("error");
+        setApiMessage("Unable to start the network client. Retry to continue.");
+      });
+
     return () => {
+      cancelled = true;
       shutdownApiClient();
     };
-  }, []);
+  }, [initAttempt]);
 
   useEffect(() => {
     if (state === "loading" || state === "locked") {
@@ -35,11 +56,29 @@ export default function RootLayout() {
     }
   }, [segments, state]);
 
-  if (state === "loading") {
+  if (apiState === "loading" || state === "loading") {
     return (
       <View style={styles.centered}>
-        <Text style={styles.title}>Securing Session</Text>
-        <Text style={styles.subtitle}>{message}</Text>
+        <Text style={styles.title}>{apiState === "loading" ? "Starting Network" : "Securing Session"}</Text>
+        <Text style={styles.subtitle}>{apiState === "loading" ? apiMessage : message}</Text>
+      </View>
+    );
+  }
+
+  if (apiState === "error") {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.title}>Startup Blocked</Text>
+        <Text style={styles.subtitle}>{apiMessage}</Text>
+        <View style={styles.spacer} />
+        <Button
+          title="Retry Network Setup"
+          onPress={() => {
+            setApiState("loading");
+            setApiMessage("Preparing offline queue and network client...");
+            setInitAttempt((current) => current + 1);
+          }}
+        />
       </View>
     );
   }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { initializeApiClient, shutdownApiClient } from "@/src/network/apiClient";
 import { Button, StyleSheet, Text, View } from "react-native";
 import { useSessionBootstrap } from "@/src/auth/useSessionBootstrap";
+import { NetworkStatusBanner } from "@/src/network/NetworkStatusBanner";
 
 const AUTH_ROUTES = new Set(["login", "register"]);
 
@@ -95,12 +96,15 @@ export default function RootLayout() {
   }
 
   return (
-    <Stack screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="index" />
-      <Stack.Screen name="profile" />
-      <Stack.Screen name="login" />
-      <Stack.Screen name="register" />
-    </Stack>
+    <>
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="index" />
+        <Stack.Screen name="profile" />
+        <Stack.Screen name="login" />
+        <Stack.Screen name="register" />
+      </Stack>
+      <NetworkStatusBanner />
+    </>
   );
 }
 

--- a/apps/mobile/src/auth/secureTokens.ts
+++ b/apps/mobile/src/auth/secureTokens.ts
@@ -20,7 +20,7 @@ export const saveSessionTokens = async (tokens: SessionTokens) => {
   await Promise.all([
     secureStoreWrite(REFRESH_TOKEN_KEY, tokens.refreshToken),
     secureStoreWrite(ACCESS_TOKEN_KEY, tokens.accessToken),
-    tokens.deviceId ? secureStoreWrite(DEVICE_ID_KEY, tokens.deviceId) : Promise.resolve(),
+    tokens.deviceId ? secureStoreWrite(DEVICE_ID_KEY, tokens.deviceId) : SecureStore.deleteItemAsync(DEVICE_ID_KEY),
   ]);
 };
 

--- a/apps/mobile/src/auth/sessionBootstrap.ts
+++ b/apps/mobile/src/auth/sessionBootstrap.ts
@@ -1,11 +1,6 @@
-import axios from "axios";
 import { requestBiometricUnlock } from "./biometricGate";
-import {
-  clearStoredSessionTokens,
-  getStoredSessionTokens,
-  saveSessionTokens,
-} from "./secureTokens";
-import type { AuthSessionResponse } from "@/src/network/contracts";
+import { getStoredSessionTokens } from "./secureTokens";
+import { refreshSessionTokens } from "./sessionRefresh";
 
 type BootstrapState = "loading" | "authenticated" | "unauthenticated" | "locked";
 
@@ -14,16 +9,6 @@ export type SessionBootstrapResult = {
   message: string;
   deviceId?: string;
 };
-
-const apiBaseUrl = process.env.EXPO_PUBLIC_API_URL;
-if (!apiBaseUrl) {
-  throw new Error("EXPO_PUBLIC_API_URL is required");
-}
-
-const client = axios.create({
-  baseURL: apiBaseUrl,
-  timeout: 10000,
-});
 
 export const bootstrapSession = async (): Promise<SessionBootstrapResult> => {
   const stored = await getStoredSessionTokens();
@@ -46,29 +31,21 @@ export const bootstrapSession = async (): Promise<SessionBootstrapResult> => {
   }
 
   try {
-    const response = await client.post("/auth/refresh", {
-      refreshToken: stored.refreshToken,
-    });
-
-    const data = (response.data as AuthSessionResponse).data;
-
-    if (!data?.accessToken || !data?.refreshToken) {
-      throw new Error("Malformed refresh response");
+    const refreshed = await refreshSessionTokens();
+    if (!refreshed.success) {
+      return {
+        state: "unauthenticated",
+        message: "Session expired. Please sign in again.",
+        deviceId: undefined,
+      };
     }
-
-    await saveSessionTokens({
-      accessToken: data.accessToken,
-      refreshToken: data.refreshToken,
-      deviceId: data.deviceId || stored.deviceId || undefined,
-    });
 
     return {
       state: "authenticated",
       message: "Session unlocked and refreshed.",
-      deviceId: data.deviceId || stored.deviceId || undefined,
+      deviceId: refreshed.deviceId || stored.deviceId || undefined,
     };
   } catch {
-    await clearStoredSessionTokens();
     return {
       state: "unauthenticated",
       message: "Session expired. Please sign in again.",

--- a/apps/mobile/src/auth/sessionRefresh.ts
+++ b/apps/mobile/src/auth/sessionRefresh.ts
@@ -1,0 +1,106 @@
+import axios from "axios";
+import { clearStoredSessionTokens, getStoredSessionTokens, saveSessionTokens } from "./secureTokens";
+import { useSessionStore } from "./sessionStore";
+import type { AuthSessionResponse } from "@/src/network/contracts";
+
+const apiBaseUrl = process.env.EXPO_PUBLIC_API_URL;
+if (!apiBaseUrl) {
+  throw new Error("EXPO_PUBLIC_API_URL is required");
+}
+
+const refreshClient = axios.create({
+  baseURL: apiBaseUrl,
+  timeout: 10000,
+});
+
+export type RefreshSessionResult =
+  | {
+      success: true;
+      accessToken: string;
+      refreshToken: string;
+      deviceId?: string;
+    }
+  | {
+      success: false;
+      reason: "MISSING_REFRESH_TOKEN" | "INVALID_REFRESH_RESPONSE" | "REFRESH_FAILED";
+    };
+
+let refreshInFlight: Promise<RefreshSessionResult> | null = null;
+
+const finalizeExpiredSession = async (message: string) => {
+  await clearStoredSessionTokens();
+  useSessionStore.getState().setStateSnapshot({
+    status: "unauthenticated",
+    message,
+    deviceId: null,
+  });
+};
+
+const performRefresh = async (): Promise<RefreshSessionResult> => {
+  const stored = await getStoredSessionTokens();
+  if (!stored.refreshToken) {
+    return {
+      success: false,
+      reason: "MISSING_REFRESH_TOKEN",
+    };
+  }
+
+  try {
+    const response = await refreshClient.post(
+      "/auth/refresh",
+      {
+        refreshToken: stored.refreshToken,
+      },
+      {
+        headers: stored.deviceId ? { "x-device-id": stored.deviceId } : undefined,
+      }
+    );
+    const data = (response.data as AuthSessionResponse).data;
+    if (!data?.accessToken || !data?.refreshToken) {
+      await finalizeExpiredSession("Session expired. Please sign in again.");
+      return {
+        success: false,
+        reason: "INVALID_REFRESH_RESPONSE",
+      };
+    }
+
+    await saveSessionTokens({
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken,
+      deviceId: data.deviceId || stored.deviceId || undefined,
+    });
+
+    useSessionStore.getState().setStateSnapshot({
+      status: "authenticated",
+      message: "Session ready.",
+      deviceId: data.deviceId || stored.deviceId || null,
+    });
+
+    return {
+      success: true,
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken,
+      deviceId: data.deviceId || stored.deviceId || undefined,
+    };
+  } catch {
+    await finalizeExpiredSession("Session expired. Please sign in again.");
+    return {
+      success: false,
+      reason: "REFRESH_FAILED",
+    };
+  }
+};
+
+export const refreshSessionTokens = async (): Promise<RefreshSessionResult> => {
+  if (!refreshInFlight) {
+    refreshInFlight = performRefresh().finally(() => {
+      refreshInFlight = null;
+    });
+  }
+
+  return refreshInFlight;
+};
+
+export const clearExpiredSession = async () => {
+  await finalizeExpiredSession("Session expired. Please sign in again.");
+};

--- a/apps/mobile/src/auth/useSessionBootstrap.ts
+++ b/apps/mobile/src/auth/useSessionBootstrap.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { bootstrapSession } from "./sessionBootstrap";
 import { useSessionStore } from "./sessionStore";
 
@@ -8,8 +8,13 @@ export const useSessionBootstrap = () => {
   const [state, setState] = useState<SessionBootState>("loading");
   const [message, setMessage] = useState("Initializing secure session...");
   const setStateSnapshot = useSessionStore((stateStore) => stateStore.setStateSnapshot);
+  const runIdRef = useRef(0);
+  const mountedRef = useRef(true);
 
   const runBootstrap = useCallback(async () => {
+    const currentRun = runIdRef.current + 1;
+    runIdRef.current = currentRun;
+
     setState("loading");
     setMessage("Initializing secure session...");
     setStateSnapshot({
@@ -18,6 +23,10 @@ export const useSessionBootstrap = () => {
     });
 
     const result = await bootstrapSession();
+    if (!mountedRef.current || currentRun !== runIdRef.current) {
+      return;
+    }
+
     setState(result.state);
     setMessage(result.message);
     setStateSnapshot({
@@ -29,6 +38,9 @@ export const useSessionBootstrap = () => {
 
   useEffect(() => {
     void runBootstrap();
+    return () => {
+      mountedRef.current = false;
+    };
   }, [runBootstrap]);
 
   return {

--- a/apps/mobile/src/network/NetworkStatusBanner.tsx
+++ b/apps/mobile/src/network/NetworkStatusBanner.tsx
@@ -1,0 +1,62 @@
+import { StyleSheet, Text, View } from "react-native";
+import { useOfflineQueueStatus } from "./useOfflineQueueStatus";
+
+const buildMessage = (state: ReturnType<typeof useOfflineQueueStatus>) => {
+  if (!state.isOnline) {
+    if (state.pendingCount > 0) {
+      return `${state.pendingCount} request${state.pendingCount === 1 ? "" : "s"} queued offline`;
+    }
+    return "Offline mode active";
+  }
+
+  if (state.isFlushing && state.pendingCount > 0) {
+    return `Syncing ${state.pendingCount} queued request${state.pendingCount === 1 ? "" : "s"}`;
+  }
+
+  return null;
+};
+
+export const NetworkStatusBanner = () => {
+  const state = useOfflineQueueStatus();
+  const message = buildMessage(state);
+
+  if (!message) {
+    return null;
+  }
+
+  const toneStyle = state.isOnline ? styles.syncing : styles.offline;
+
+  return (
+    <View pointerEvents="none" style={[styles.container, toneStyle]}>
+      <Text style={styles.text}>{message}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: "absolute",
+    top: 18,
+    left: 16,
+    right: 16,
+    zIndex: 20,
+    borderRadius: 14,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderWidth: 1,
+  },
+  offline: {
+    backgroundColor: "rgba(102, 26, 26, 0.95)",
+    borderColor: "#ff9d9d",
+  },
+  syncing: {
+    backgroundColor: "rgba(17, 66, 84, 0.95)",
+    borderColor: "#97ecff",
+  },
+  text: {
+    color: "#f7fbff",
+    fontSize: 13,
+    fontWeight: "700",
+    textAlign: "center",
+  },
+});

--- a/apps/mobile/src/network/apiClient.ts
+++ b/apps/mobile/src/network/apiClient.ts
@@ -4,6 +4,7 @@ import { enqueueRequest, flushQueuedRequests, getPendingQueueCount } from "./off
 import { getQueueState, setQueueState } from "./queueState";
 import { QueuedRequest, isQueueableMethod } from "./types";
 import { getStoredSessionTokens } from "@/src/auth/secureTokens";
+import { clearExpiredSession, refreshSessionTokens } from "@/src/auth/sessionRefresh";
 
 const baseURL = process.env.EXPO_PUBLIC_API_URL;
 if (!baseURL) {
@@ -61,69 +62,97 @@ let initialized = false;
 let unsubscribeNetInfo: (() => void) | null = null;
 let responseInterceptorId: number | null = null;
 let requestInterceptorId: number | null = null;
+let initializationPromise: Promise<void> | null = null;
 
 export const initializeApiClient = async () => {
   if (initialized) {
     return;
   }
-  initialized = true;
-
-  const pendingCount = await getPendingQueueCount();
-  setQueueState({ pendingCount });
-
-  const current = await NetInfo.fetch();
-  const initialOnline = Boolean(current.isConnected && current.isInternetReachable !== false);
-  setQueueState({ isOnline: initialOnline });
-
-  if (initialOnline) {
-    await flushQueuedRequests(apiClient);
+  if (initializationPromise) {
+    return initializationPromise;
   }
 
-  requestInterceptorId = apiClient.interceptors.request.use(
-    async (config) => {
-      const stored = await getStoredSessionTokens();
-      if (stored.accessToken) {
-        config.headers.set("Authorization", `Bearer ${stored.accessToken}`);
-      }
-      if (stored.deviceId) {
-        config.headers.set("x-device-id", stored.deviceId);
-      }
-      return config;
-    },
-    (error) => Promise.reject(error)
-  );
+  initializationPromise = (async () => {
+    initialized = true;
 
-  responseInterceptorId = apiClient.interceptors.response.use(
-    (response) => response,
-    async (error: AxiosError) => {
-      const config = error.config;
-      if (!config) {
-        return Promise.reject(error);
-      }
-      if (hasSkipQueueFlag(config)) {
-        return Promise.reject(error);
-      }
-      if (!isQueueableMethod(config.method)) {
-        return Promise.reject(error);
-      }
-      if (!isNetworkFailure(error)) {
-        return Promise.reject(error);
-      }
+    const pendingCount = await getPendingQueueCount();
+    setQueueState({ pendingCount });
 
-      await enqueueRequest(toQueuedRequest(config));
-      return Promise.resolve(createQueuedResponse(config));
-    },
-  );
+    const current = await NetInfo.fetch();
+    const initialOnline = Boolean(current.isConnected && current.isInternetReachable !== false);
+    setQueueState({ isOnline: initialOnline });
 
-  unsubscribeNetInfo = NetInfo.addEventListener(async (state) => {
-    const nowOnline = Boolean(state.isConnected && state.isInternetReachable !== false);
-    const previousOnline = getQueueState().isOnline;
-    setQueueState({ isOnline: nowOnline });
-
-    if (!previousOnline && nowOnline) {
+    if (initialOnline) {
       await flushQueuedRequests(apiClient);
     }
-  });
+
+    requestInterceptorId = apiClient.interceptors.request.use(
+      async (config) => {
+        const stored = await getStoredSessionTokens();
+        if (stored.accessToken) {
+          config.headers.set("Authorization", `Bearer ${stored.accessToken}`);
+        }
+        if (stored.deviceId) {
+          config.headers.set("x-device-id", stored.deviceId);
+        }
+        return config;
+      },
+      (error) => Promise.reject(error)
+    );
+
+    responseInterceptorId = apiClient.interceptors.response.use(
+      (response) => response,
+      async (error: AxiosError) => {
+        const config = error.config;
+        if (!config) {
+          return Promise.reject(error);
+        }
+
+        if (shouldAttemptSessionRefresh(error, config)) {
+          const refreshed = await refreshSessionTokens();
+          if (refreshed.success) {
+            config.headers.set("Authorization", `Bearer ${refreshed.accessToken}`);
+            setRetryAuthRefresh(config, true);
+            return apiClient.request(config);
+          }
+
+          await clearExpiredSession();
+          return Promise.reject(error);
+        }
+
+        if (hasSkipQueueFlag(config)) {
+          return Promise.reject(error);
+        }
+        if (!isQueueableMethod(config.method)) {
+          return Promise.reject(error);
+        }
+        if (!isNetworkFailure(error)) {
+          return Promise.reject(error);
+        }
+
+        await enqueueRequest(toQueuedRequest(config));
+        return Promise.resolve(createQueuedResponse(config));
+      },
+    );
+
+    unsubscribeNetInfo = NetInfo.addEventListener(async (state) => {
+      const nowOnline = Boolean(state.isConnected && state.isInternetReachable !== false);
+      const previousOnline = getQueueState().isOnline;
+      setQueueState({ isOnline: nowOnline });
+
+      if (!previousOnline && nowOnline) {
+        await flushQueuedRequests(apiClient);
+      }
+    });
+  })();
+
+  try {
+    await initializationPromise;
+  } catch (error) {
+    initialized = false;
+    initializationPromise = null;
+    throw error;
+  }
 };
 
 export const shutdownApiClient = () => {
@@ -140,6 +169,7 @@ export const shutdownApiClient = () => {
     requestInterceptorId = null;
   }
   initialized = false;
+  initializationPromise = null;
 };
 
 export const flushPendingRequests = async () => {
@@ -153,4 +183,31 @@ const hasSkipQueueFlag = (config?: InternalAxiosRequestConfig): boolean => {
   if (!config) return false;
   const metadata = (config as InternalAxiosRequestConfig & { metadata?: { skipQueue?: boolean } }).metadata;
   return Boolean(metadata?.skipQueue);
+};
+
+const hasRetriedAuthRefresh = (config?: InternalAxiosRequestConfig): boolean => {
+  if (!config) return false;
+  const metadata = (config as InternalAxiosRequestConfig & { metadata?: { retriedAuthRefresh?: boolean } }).metadata;
+  return Boolean(metadata?.retriedAuthRefresh);
+};
+
+const setRetryAuthRefresh = (config: InternalAxiosRequestConfig, value: boolean) => {
+  const metadata =
+    (config as InternalAxiosRequestConfig & { metadata?: { retriedAuthRefresh?: boolean } }).metadata || {};
+  metadata.retriedAuthRefresh = value;
+  (config as InternalAxiosRequestConfig & { metadata?: { retriedAuthRefresh?: boolean } }).metadata = metadata;
+};
+
+const shouldAttemptSessionRefresh = (error: AxiosError, config: InternalAxiosRequestConfig): boolean => {
+  if (error.response?.status !== 401) {
+    return false;
+  }
+  if (hasRetriedAuthRefresh(config)) {
+    return false;
+  }
+  const requestUrl = String(config.url || "");
+  if (requestUrl.includes("/auth/login") || requestUrl.includes("/auth/register") || requestUrl.includes("/auth/refresh")) {
+    return false;
+  }
+  return true;
 };


### PR DESCRIPTION

- unify mobile session refresh logic across cold start and runtime auth recovery
- prevent stale bootstrap state updates after async auth work
- retry expired access tokens once inside the mobile API client before forcing sign-in
- make network/offline queue startup explicit and retryable in the root layout
- add a reusable network status banner for offline and reconnecting states

closes #168
closes #169
closes #170
closes #171