### PR TITLE
fe: map modules, permission education, recovery hook, detail model

### DIFF
--- a/apps/mobile/src/location/LocationPermissionEducation.tsx
+++ b/apps/mobile/src/location/LocationPermissionEducation.tsx
@@ -1,0 +1,50 @@
+/**
+ * LocationPermissionEducation – reusable component that explains why location
+ * access is needed before the system prompt is shown.
+ * Issue #173
+ */
+
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+type Props = {
+  message: string;
+  onAllow: () => void;
+  onSkip?: () => void;
+};
+
+export function LocationPermissionEducation({ message, onAllow, onSkip }: Props) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.icon}>📍</Text>
+      <Text style={styles.heading}>Allow location access</Text>
+      <Text style={styles.body}>{message}</Text>
+
+      <Pressable style={styles.primaryBtn} onPress={onAllow}>
+        <Text style={styles.primaryLabel}>Allow location</Text>
+      </Pressable>
+
+      {onSkip ? (
+        <Pressable style={styles.skipBtn} onPress={onSkip}>
+          <Text style={styles.skipLabel}>Not now</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+    backgroundColor: "#080c12",
+  },
+  icon:        { fontSize: 48, marginBottom: 16 },
+  heading:     { color: "#ffffff", fontSize: 22, fontWeight: "700", marginBottom: 12, textAlign: "center" },
+  body:        { color: "#cfe0ef", fontSize: 15, textAlign: "center", lineHeight: 22, marginBottom: 32 },
+  primaryBtn:  { backgroundColor: "#1a73e8", borderRadius: 10, paddingVertical: 14, paddingHorizontal: 40, marginBottom: 12 },
+  primaryLabel:{ color: "#ffffff", fontSize: 16, fontWeight: "600" },
+  skipBtn:     { paddingVertical: 10 },
+  skipLabel:   { color: "#8ea2b5", fontSize: 14 },
+});

--- a/apps/mobile/src/location/usePermissionRecovery.ts
+++ b/apps/mobile/src/location/usePermissionRecovery.ts
@@ -1,0 +1,54 @@
+/**
+ * usePermissionRecovery – provides recovery actions when foreground location
+ * permission has been permanently denied.
+ * Issue #174
+ */
+
+import { useCallback, useState } from "react";
+import { Linking, Platform } from "react-native";
+
+export type RecoveryState = "idle" | "opening-settings" | "opened" | "error";
+
+export interface PermissionRecovery {
+  recoveryState: RecoveryState;
+  canOpenSettings: boolean;
+  openAppSettings: () => Promise<void>;
+  reset: () => void;
+}
+
+const SETTINGS_URL = Platform.select({
+  ios: "app-settings:",
+  android: "package:com.qyou.app",
+  default: "",
+});
+
+export const usePermissionRecovery = (): PermissionRecovery => {
+  const [recoveryState, setRecoveryState] = useState<RecoveryState>("idle");
+
+  const canOpenSettings = Boolean(SETTINGS_URL);
+
+  const openAppSettings = useCallback(async () => {
+    if (!SETTINGS_URL) {
+      setRecoveryState("error");
+      return;
+    }
+
+    setRecoveryState("opening-settings");
+
+    try {
+      const supported = await Linking.canOpenURL(SETTINGS_URL);
+      if (!supported) {
+        setRecoveryState("error");
+        return;
+      }
+      await Linking.openURL(SETTINGS_URL);
+      setRecoveryState("opened");
+    } catch {
+      setRecoveryState("error");
+    }
+  }, []);
+
+  const reset = useCallback(() => setRecoveryState("idle"), []);
+
+  return { recoveryState, canOpenSettings, openAppSettings, reset };
+};

--- a/apps/mobile/src/map/MapScreenModules.ts
+++ b/apps/mobile/src/map/MapScreenModules.ts
@@ -1,0 +1,50 @@
+/**
+ * MapScreenModules – route and feature module registry for the map screen.
+ * Keeps apps/mobile/app/index.tsx thin by declaring each sub-concern here.
+ * Issue #172
+ */
+
+export type MapFeatureModule =
+  | "location-engine"
+  | "bounding-box-polling"
+  | "cluster-renderer"
+  | "bottom-sheet"
+  | "network-banner";
+
+export type MapRouteModule = "index" | "location-detail" | "report";
+
+export interface ModuleDescriptor {
+  id: MapFeatureModule | MapRouteModule;
+  lazy: boolean;
+  requiresAuth: boolean;
+  requiresLocation: boolean;
+}
+
+const FEATURE_MODULES: ModuleDescriptor[] = [
+  { id: "location-engine",      lazy: false, requiresAuth: false, requiresLocation: false },
+  { id: "bounding-box-polling", lazy: false, requiresAuth: false, requiresLocation: true  },
+  { id: "cluster-renderer",     lazy: true,  requiresAuth: false, requiresLocation: true  },
+  { id: "bottom-sheet",         lazy: true,  requiresAuth: false, requiresLocation: false },
+  { id: "network-banner",       lazy: false, requiresAuth: false, requiresLocation: false },
+];
+
+const ROUTE_MODULES: ModuleDescriptor[] = [
+  { id: "index",           lazy: false, requiresAuth: false, requiresLocation: false },
+  { id: "location-detail", lazy: true,  requiresAuth: false, requiresLocation: false },
+  { id: "report",          lazy: true,  requiresAuth: true,  requiresLocation: true  },
+];
+
+export const getAllModules = (): ModuleDescriptor[] => [
+  ...FEATURE_MODULES,
+  ...ROUTE_MODULES,
+];
+
+export const getModulesRequiringLocation = (): ModuleDescriptor[] =>
+  getAllModules().filter((m) => m.requiresLocation);
+
+export const getModulesRequiringAuth = (): ModuleDescriptor[] =>
+  getAllModules().filter((m) => m.requiresAuth);
+
+export const findModule = (
+  id: MapFeatureModule | MapRouteModule
+): ModuleDescriptor | undefined => getAllModules().find((m) => m.id === id);

--- a/apps/mobile/src/map/locationDetailModel.ts
+++ b/apps/mobile/src/map/locationDetailModel.ts
@@ -1,0 +1,51 @@
+/**
+ * locationDetailModel – normalises NearbyLocationItem and LocationDetailsItem
+ * into a single LocationSheetDetails shape so the bottom-sheet never needs
+ * ad hoc casts between the two API response types.
+ * Issue #175
+ */
+
+import type { LocationDetailsItem, NearbyLocationItem } from "@qyou/types";
+import type { LocationSheetDetails } from "./LocationBottomSheet";
+
+export const fromNearby = (item: NearbyLocationItem): LocationSheetDetails => ({
+  id: item._id,
+  name: item.name,
+  type: item.type,
+  address: item.address ?? "",
+  status: item.status,
+  distanceFromUser: item.distanceFromUser,
+  queueSnapshot: item.queueSnapshot
+    ? {
+        level: item.queueSnapshot.level,
+        estimatedWaitMinutes: item.queueSnapshot.estimatedWaitMinutes,
+        confidence: item.queueSnapshot.confidence,
+        lastUpdatedAt: item.queueSnapshot.lastUpdatedAt ?? null,
+        isStale: item.queueSnapshot.isStale,
+      }
+    : undefined,
+});
+
+export const fromDetail = (item: LocationDetailsItem): LocationSheetDetails => ({
+  id: item._id,
+  name: item.name,
+  type: item.type,
+  address: item.address ?? "",
+  status: item.status,
+  distanceFromUser: undefined,
+  queueSnapshot: item.queueSnapshot
+    ? {
+        level: item.queueSnapshot.level,
+        estimatedWaitMinutes: item.queueSnapshot.estimatedWaitMinutes,
+        confidence: item.queueSnapshot.confidence,
+        lastUpdatedAt: item.queueSnapshot.lastUpdatedAt ?? null,
+        isStale: item.queueSnapshot.isStale,
+      }
+    : undefined,
+});
+
+/** Merge a nearby stub with a freshly-fetched detail, preferring detail fields. */
+export const mergeDetailOntoNearby = (
+  nearby: LocationSheetDetails,
+  detail: LocationDetailsItem
+): LocationSheetDetails => ({ ...fromDetail(detail), distanceFromUser: nearby.distanceFromUser });


### PR DESCRIPTION
Closes #172, closes #173, closes #174, closes #175

- **#172** – Added `MapScreenModules.ts` to declare route and feature module descriptors, keeping `index.tsx` thin as queue discovery grows.
- **#173** – Extracted `LocationPermissionEducation` into a standalone component for consistent permission UX and easier testing.
- **#174** – Added `usePermissionRecovery` hook that opens app settings when foreground location is permanently denied.
- **#175** – Added `locationDetailModel.ts` with `fromNearby`, `fromDetail`, and `mergeDetailOntoNearby` to eliminate ad hoc casts between nearby and detail API responses.