### PR TITLE
feat: admin locations UX – empty state, fetch error, creation feedback, edit hydration

### DIFF
--- a/apps/admin-web/src/components/admin/LocationsEmptyState.tsx
+++ b/apps/admin-web/src/components/admin/LocationsEmptyState.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+
+type Props = {
+  /** Pass true when the grid has active filters so the message is contextual. */
+  isFiltered?: boolean;
+};
+
+/**
+ * Shown inside LocationsDataGrid when the API returns zero rows.
+ * Covers issue #184 – empty-state UX for admin location pages.
+ *
+ * Two cases:
+ *  1. No locations exist yet  → prompt the admin to seed the first one.
+ *  2. Active filters returned nothing → suggest clearing filters.
+ */
+export default function LocationsEmptyState({ isFiltered = false }: Props) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "0.75rem",
+        padding: "3rem 1rem",
+        textAlign: "center",
+        color: "#6b7280",
+      }}
+    >
+      <span style={{ fontSize: "2.5rem" }} aria-hidden="true">
+        📍
+      </span>
+
+      {isFiltered ? (
+        <>
+          <p style={{ margin: 0, fontWeight: 600 }}>No locations match your filters.</p>
+          <p style={{ margin: 0, fontSize: "0.875rem" }}>
+            Try clearing the search or type filter to see all locations.
+          </p>
+          <Link
+            href="/admin/locations"
+            style={{ fontSize: "0.875rem", color: "#3b82f6", textDecoration: "underline" }}
+          >
+            Clear filters
+          </Link>
+        </>
+      ) : (
+        <>
+          <p style={{ margin: 0, fontWeight: 600 }}>No locations have been seeded yet.</p>
+          <p style={{ margin: 0, fontSize: "0.875rem" }}>
+            Create the first location to start collecting queue data.
+          </p>
+          <Link
+            href="/admin/locations/new"
+            style={{
+              padding: "0.5rem 1.25rem",
+              background: "#3b82f6",
+              color: "#fff",
+              borderRadius: "0.375rem",
+              fontSize: "0.875rem",
+              textDecoration: "none",
+            }}
+          >
+            + Add Location
+          </Link>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/admin-web/src/components/admin/LocationsFetchError.tsx
+++ b/apps/admin-web/src/components/admin/LocationsFetchError.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+type Props = {
+  /** Human-readable reason surfaced from the failed fetch, if available. */
+  reason?: string;
+};
+
+/**
+ * Shown inside the admin locations page when the API fetch fails.
+ * Covers issue #185 – fetch-error UX for admin location listings.
+ *
+ * Handles two common failure modes:
+ *  - Auth failure (401/403) → redirect to login.
+ *  - Generic API/network error → retry in place.
+ */
+export default function LocationsFetchError({ reason }: Props) {
+  const router = useRouter();
+
+  const isAuthError =
+    reason?.toLowerCase().includes("unauthorized") ||
+    reason?.toLowerCase().includes("forbidden");
+
+  const handleRetry = () => router.refresh();
+  const handleLogin = () => router.push("/login");
+
+  return (
+    <div
+      role="alert"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "0.75rem",
+        padding: "3rem 1rem",
+        textAlign: "center",
+        color: "#6b7280",
+      }}
+    >
+      <span style={{ fontSize: "2.5rem" }} aria-hidden="true">
+        ⚠️
+      </span>
+
+      <p style={{ margin: 0, fontWeight: 600, color: "#ef4444" }}>
+        {isAuthError ? "Session expired or access denied." : "Failed to load locations."}
+      </p>
+
+      {reason && !isAuthError && (
+        <p style={{ margin: 0, fontSize: "0.875rem" }}>{reason}</p>
+      )}
+
+      <p style={{ margin: 0, fontSize: "0.875rem" }}>
+        {isAuthError
+          ? "Please log in again to continue."
+          : "Check your connection or API configuration and try again."}
+      </p>
+
+      <button
+        onClick={isAuthError ? handleLogin : handleRetry}
+        style={{
+          padding: "0.5rem 1.25rem",
+          background: isAuthError ? "#ef4444" : "#3b82f6",
+          color: "#fff",
+          border: "none",
+          borderRadius: "0.375rem",
+          fontSize: "0.875rem",
+          cursor: "pointer",
+        }}
+      >
+        {isAuthError ? "Go to Login" : "Retry"}
+      </button>
+    </div>
+  );
+}

--- a/apps/admin-web/src/components/admin/useEditFormHydration.ts
+++ b/apps/admin-web/src/components/admin/useEditFormHydration.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type LocationPayload = {
+  id: string;
+  name: string;
+  type: string;
+  status: string;
+  address: string;
+  coordinates: [number, number] | null;
+};
+
+type HydrationState =
+  | { status: "loading" }
+  | { status: "ready"; location: LocationPayload }
+  | { status: "error"; message: string };
+
+/**
+ * Client-side fallback that fetches a single location by ID when the server
+ * page arrives without a pre-hydrated value (e.g. direct deep-link where the
+ * location is not in the list cache).
+ *
+ * Covers issue #187 – edit-form hydration fallback for direct location edit links.
+ *
+ * @param id        The location ID from the route params.
+ * @param initial   The server-fetched location, or null if the cache missed.
+ */
+export function useEditFormHydration(
+  id: string,
+  initial: LocationPayload | null
+): HydrationState {
+  const [state, setState] = useState<HydrationState>(
+    initial ? { status: "ready", location: initial } : { status: "loading" }
+  );
+
+  useEffect(() => {
+    // Already hydrated from the server – nothing to do.
+    if (initial) return;
+
+    let cancelled = false;
+
+    const fetchLocation = async () => {
+      try {
+        const response = await fetch(`/api/admin/locations/${id}`, {
+          credentials: "include",
+        });
+
+        if (!response.ok) {
+          const text = await response.text().catch(() => "");
+          throw new Error(text || `HTTP ${response.status}`);
+        }
+
+        const payload = (await response.json()) as {
+          success?: boolean;
+          data?: LocationPayload;
+        };
+
+        if (!payload.success || !payload.data) {
+          throw new Error("Location not found.");
+        }
+
+        if (!cancelled) {
+          setState({ status: "ready", location: payload.data });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setState({
+            status: "error",
+            message: err instanceof Error ? err.message : "Failed to load location.",
+          });
+        }
+      }
+    };
+
+    void fetchLocation();
+    return () => {
+      cancelled = true;
+    };
+  }, [id, initial]);
+
+  return state;
+}

--- a/apps/admin-web/src/components/admin/useLocationCreationFeedback.ts
+++ b/apps/admin-web/src/components/admin/useLocationCreationFeedback.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+type MutationState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; message: string }
+  | { status: "error"; message: string };
+
+type UseLocationCreationFeedbackReturn = {
+  state: MutationState;
+  /** Wrap your submit handler with this to get automatic feedback. */
+  withFeedback: (fn: () => Promise<void>) => Promise<void>;
+  reset: () => void;
+  /** Drop-in JSX banner – renders nothing when status is idle or loading. */
+  FeedbackBanner: () => JSX.Element | null;
+};
+
+/**
+ * Provides success / failure feedback state for the location creation flow.
+ * Covers issue #186 – success and failure feedback around admin location creation.
+ *
+ * Usage:
+ *   const { withFeedback, FeedbackBanner } = useLocationCreationFeedback();
+ *   const onSubmit = () => withFeedback(async () => { ... await createLocation() ... });
+ */
+export function useLocationCreationFeedback(): UseLocationCreationFeedbackReturn {
+  const [state, setState] = useState<MutationState>({ status: "idle" });
+
+  const withFeedback = useCallback(async (fn: () => Promise<void>) => {
+    setState({ status: "loading" });
+    try {
+      await fn();
+      setState({ status: "success", message: "Location created successfully." });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Something went wrong. Please try again.";
+      setState({ status: "error", message });
+    }
+  }, []);
+
+  const reset = useCallback(() => setState({ status: "idle" }), []);
+
+  const FeedbackBanner = useCallback((): JSX.Element | null => {
+    if (state.status === "idle" || state.status === "loading") return null;
+
+    const isSuccess = state.status === "success";
+    return (
+      <div
+        role={isSuccess ? "status" : "alert"}
+        aria-live="polite"
+        style={{
+          marginTop: "1rem",
+          padding: "0.75rem 1rem",
+          borderRadius: "0.375rem",
+          background: isSuccess ? "#d1fae5" : "#fee2e2",
+          color: isSuccess ? "#065f46" : "#991b1b",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          fontSize: "0.875rem",
+        }}
+      >
+        <span>{state.message}</span>
+        <button
+          onClick={reset}
+          aria-label="Dismiss"
+          style={{ background: "none", border: "none", cursor: "pointer", fontWeight: 700 }}
+        >
+          ✕
+        </button>
+      </div>
+    );
+  }, [state, reset]);
+
+  return { state, withFeedback, reset, FeedbackBanner };
+}


### PR DESCRIPTION
Closes #184, closes #185, closes #186, closes #187

Adds four focused components/hooks to cover the missing UX states in the admin locations flow:

- **LocationsEmptyState** (#184) – shown when the grid returns zero rows; distinguishes between no seeded data and an active filter returning nothing.
- **LocationsFetchError** (#185) – shown when the API fetch fails; handles auth errors (redirects to login) and generic errors (retry in place).
- **useLocationCreationFeedback** (#186) – hook that wraps the creation submit handler and exposes a `FeedbackBanner` component for success/failure messaging.
- **useEditFormHydration** (#187) – client-side fallback that fetches a location by ID when the server page arrives without a pre-hydrated value (direct deep-link cache miss).