### PR TITLE
fe: admin auth layout, session expiry, type normalization, server/client split

### DIFF
--- a/apps/admin-web/src/app/admin/layout.tsx
+++ b/apps/admin-web/src/app/admin/layout.tsx
@@ -1,0 +1,9 @@
+import AdminLayoutClient from "@/components/admin/AdminLayoutClient";
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <AdminLayoutClient>{children}</AdminLayoutClient>;
+}

--- a/apps/admin-web/src/app/admin/locations/page.tsx
+++ b/apps/admin-web/src/app/admin/locations/page.tsx
@@ -1,6 +1,4 @@
-import { cookies } from "next/headers";
-import LocationsDataGrid, { GridRow } from "@/components/admin/LocationsDataGrid";
-import type { AdminLocationsListResponse } from "@/src/lib/api";
+import LocationsPageServer from "@/components/admin/LocationsPageServer";
 
 type SearchParams = {
   page?: string;
@@ -11,68 +9,24 @@ type SearchParams = {
   type?: string;
 };
 
-const toPositiveInt = (value: string | undefined, fallback: number) => {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
-  return Math.floor(parsed);
+const toPositiveInt = (v: string | undefined, fallback: number) => {
+  const n = Number(v);
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : fallback;
 };
 
 export default async function AdminLocationsPage(props: {
   searchParams?: Promise<SearchParams> | SearchParams;
 }) {
-  const resolved = await Promise.resolve(props.searchParams || {});
-  const page = toPositiveInt(resolved.page, 1);
-  const pageSize = Math.min(toPositiveInt(resolved.pageSize, 50), 50);
-  const sort = resolved.sort || "createdAt";
-  const dir = resolved.dir === "asc" ? "asc" : "desc";
-  const search = resolved.search || "";
-  const type = resolved.type || "";
-
-  const cookieStore = await cookies();
-  const authCookieName = process.env.ADMIN_AUTH_COOKIE || "admin_token";
-  const token = cookieStore.get(authCookieName)?.value || "";
-  const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
-
-  let rows: GridRow[] = [];
-  let total = 0;
-  let totalPages = 1;
-
-  if (apiBase && token) {
-    const query = new URLSearchParams({
-      page: String(page),
-      pageSize: String(pageSize),
-      sort,
-      dir,
-    });
-    if (search) query.set("search", search);
-    if (type) query.set("type", type);
-
-    const response = await fetch(`${apiBase}/admin/locations?${query.toString()}`, {
-      cache: "no-store",
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-
-    if (response.ok) {
-      const payload = (await response.json()) as AdminLocationsListResponse;
-      rows = payload.data?.rows || [];
-      total = payload.data?.pagination.total || 0;
-      totalPages = payload.data?.pagination.totalPages || 1;
-    }
-  }
+  const sp = await Promise.resolve(props.searchParams ?? {});
 
   return (
-    <LocationsDataGrid
-      rows={rows}
-      page={page}
-      pageSize={pageSize}
-      total={total}
-      totalPages={totalPages}
-      sort={sort}
-      dir={dir}
-      search={search}
-      typeFilter={type}
+    <LocationsPageServer
+      page={toPositiveInt(sp.page, 1)}
+      pageSize={Math.min(toPositiveInt(sp.pageSize, 50), 50)}
+      sort={sp.sort ?? "createdAt"}
+      dir={sp.dir === "asc" ? "asc" : "desc"}
+      search={sp.search ?? ""}
+      type={sp.type ?? ""}
     />
   );
 }

--- a/apps/admin-web/src/components/admin/AdminLayoutClient.tsx
+++ b/apps/admin-web/src/components/admin/AdminLayoutClient.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSessionExpiryRedirect } from "@/lib/session";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+/**
+ * Client wrapper that mounts session-expiry redirect handling for every
+ * admin route. Server layout (apps/admin-web/src/app/admin/layout.tsx)
+ * renders this so auth logic lives in one place.
+ */
+export default function AdminLayoutClient({ children }: Props) {
+  useSessionExpiryRedirect();
+
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    // Verify the session cookie is still present on the client side.
+    // The middleware already validates the JWT; this is a lightweight
+    // guard against a cleared cookie without a full page reload.
+    const hasCookie = document.cookie
+      .split(";")
+      .some((c) => c.trim().startsWith("admin_token="));
+
+    if (!hasCookie) {
+      router.replace("/login");
+    } else {
+      setReady(true);
+    }
+  }, [router]);
+
+  if (!ready) {
+    return (
+      <div role="status" aria-live="polite" style={{ padding: 32 }}>
+        Loading…
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/admin-web/src/components/admin/LocationsPageServer.tsx
+++ b/apps/admin-web/src/components/admin/LocationsPageServer.tsx
@@ -1,0 +1,71 @@
+import { cookies } from "next/headers";
+import LocationsDataGrid, { GridRow } from "@/components/admin/LocationsDataGrid";
+import type { AdminLocationsListResponse } from "@/lib/api";
+
+interface Props {
+  page: number;
+  pageSize: number;
+  sort: string;
+  dir: "asc" | "desc";
+  search: string;
+  type: string;
+}
+
+/**
+ * Pure server component: owns all data fetching for the locations grid.
+ * The page file resolves searchParams and delegates here; the grid
+ * component stays a pure client presentational component.
+ */
+export default async function LocationsPageServer({
+  page,
+  pageSize,
+  sort,
+  dir,
+  search,
+  type,
+}: Props) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(process.env.ADMIN_AUTH_COOKIE || "admin_token")?.value ?? "";
+  const apiBase = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+  let rows: GridRow[] = [];
+  let total = 0;
+  let totalPages = 1;
+
+  if (apiBase && token) {
+    const query = new URLSearchParams({ page: String(page), pageSize: String(pageSize), sort, dir });
+    if (search) query.set("search", search);
+    if (type) query.set("type", type);
+
+    try {
+      const res = await fetch(`${apiBase}/admin/locations?${query}`, {
+        cache: "no-store",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const payload = (await res.json()) as AdminLocationsListResponse;
+        if (payload.success) {
+          rows = payload.data.rows;
+          total = payload.data.pagination.total;
+          totalPages = payload.data.pagination.totalPages;
+        }
+      }
+    } catch {
+      // network failure — render empty grid with no crash
+    }
+  }
+
+  return (
+    <LocationsDataGrid
+      rows={rows}
+      page={page}
+      pageSize={pageSize}
+      total={total}
+      totalPages={totalPages}
+      sort={sort}
+      dir={dir}
+      search={search}
+      typeFilter={type}
+    />
+  );
+}

--- a/apps/admin-web/src/lib/api.ts
+++ b/apps/admin-web/src/lib/api.ts
@@ -1,20 +1,9 @@
-import type { ApiResponse, AdminLocationRow } from "@qyou/types";
-
-export type AdminLocationsListResponse = ApiResponse<{
-  rows: AdminLocationRow[];
-  pagination: {
-    page: number;
-    pageSize: number;
-    total: number;
-    totalPages: number;
-  };
-  sort: {
-    field: string;
-    direction: "asc" | "desc";
-  };
-  filters: {
-    search: string | null;
-    type: string | null;
-  };
-}>;
-
+export type {
+  AdminLocationsListResponse,
+  AdminLocationDetailResponse,
+  AdminLocationCreateResponse,
+  AdminLocationUpdateResponse,
+  AdminLocationRow,
+  AdminLocationDetail,
+  AdminLocationsListPayload,
+} from "@qyou/types";

--- a/apps/admin-web/src/lib/session.ts
+++ b/apps/admin-web/src/lib/session.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+const SESSION_EXPIRY_EVENT = "admin:session-expired";
+
+export function emitSessionExpired() {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(SESSION_EXPIRY_EVENT));
+  }
+}
+
+/**
+ * Hook: listens for session-expiry events and redirects to /login.
+ * Mount once in a client layout that wraps all admin pages.
+ */
+export function useSessionExpiryRedirect() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handler = () => router.replace("/login");
+    window.addEventListener(SESSION_EXPIRY_EVENT, handler);
+    return () => window.removeEventListener(SESSION_EXPIRY_EVENT, handler);
+  }, [router]);
+}
+
+/**
+ * Wraps fetch; on 401 it emits the session-expiry event so the
+ * useSessionExpiryRedirect hook can redirect without coupling
+ * every call-site to the router.
+ */
+export async function adminFetch(
+  input: RequestInfo,
+  init?: RequestInit
+): Promise<Response> {
+  const res = await fetch(input, init);
+  if (res.status === 401) {
+    emitSessionExpired();
+  }
+  return res;
+}

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -134,3 +134,31 @@ export type RewardBalance = {
   lifetimeEarned?: number;
   lastUpdatedAt?: string;
 };
+
+// ── Admin location API contracts ──────────────────────────────────────────────
+
+export type AdminLocationRow = {
+  id: string;
+  name: string;
+  type: LocationType;
+  address: string;
+  status: LocationStatus;
+  coordinates: [number, number] | null; // [lng, lat]
+  createdAt?: string;
+};
+
+export type AdminLocationDetail = Location;
+
+export type AdminLocationsListPayload = {
+  rows: AdminLocationRow[];
+  pagination: { page: number; pageSize: number; total: number; totalPages: number };
+  sort: { field: string; direction: "asc" | "desc" };
+  filters: { search: string | null; type: string | null };
+};
+
+export type AdminLocationMutationPayload = { location: AdminLocationDetail };
+
+export type AdminLocationsListResponse = ApiResponse<AdminLocationsListPayload>;
+export type AdminLocationDetailResponse = ApiResponse<AdminLocationMutationPayload>;
+export type AdminLocationCreateResponse = ApiResponse<AdminLocationMutationPayload>;
+export type AdminLocationUpdateResponse = ApiResponse<AdminLocationMutationPayload>;


### PR DESCRIPTION
Closes #180, closes #181, closes #182, closes #183

**#180 – Session-expiry redirect handling**
Added `src/lib/session.ts` with `adminFetch` (emits a session-expired event on 401) and `useSessionExpiryRedirect` hook that listens for the event and calls `router.replace('/login')`.

**#181 – Protected admin layout wrapper**
Added `src/app/admin/layout.tsx` (server) + `AdminLayoutClient` (client) that mounts the session-expiry hook and guards against a missing cookie before rendering children.

**#182 – Normalize admin API response typings**
Moved `AdminLocationRow`, `AdminLocationsListPayload`, and all admin mutation response types into `libs/types/src/index.ts`. `apps/admin-web/src/lib/api.ts` now re-exports from there instead of redefining payloads locally.

**#183 – Split server/client responsibilities for locations grid**
Extracted `LocationsPageServer` (async server component, owns data fetching) so `admin/locations/page.tsx` only resolves searchParams and delegates. `LocationsDataGrid` stays a pure client presentational component.