### PR TITLE
feat(api): bootstrap refactor, readiness route, and env validation

### DIFF
--- a/apps/api/app.ts
+++ b/apps/api/app.ts
@@ -1,0 +1,38 @@
+import 'dotenv/config';
+import cors from 'cors';
+import express from 'express';
+
+import { errorHandler } from './middleware/errorHandler';
+import { notFoundHandler } from './middleware/notFound';
+import { requestMetricsMiddleware } from './middleware/observability';
+import { adminAuditLogsRouter } from './routes/adminAuditLogs';
+import { adminLocationSeedRouter } from './routes/adminLocationSeed';
+import { authRouter } from './routes/auth';
+import { internalMetricsRouter } from './routes/internalMetrics';
+import { locationsRouter } from './routes/locations';
+import { readinessRouter } from './routes/readiness';
+
+export function createApp() {
+  const app = express();
+
+  app.use(cors());
+  app.use(express.json());
+  app.use(requestMetricsMiddleware);
+
+  app.use('/auth', authRouter);
+  app.use('/admin', adminLocationSeedRouter);
+  app.use('/admin/audit', adminAuditLogsRouter);
+  app.use('/internal', internalMetricsRouter);
+  app.use('/locations', locationsRouter);
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok', service: 'Qyou API', timestamp: new Date() });
+  });
+
+  app.use('/ready', readinessRouter);
+
+  app.use(notFoundHandler);
+  app.use(errorHandler);
+
+  return app;
+}

--- a/apps/api/routes/readiness.ts
+++ b/apps/api/routes/readiness.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import mongoose from 'mongoose';
+
+const router = Router();
+
+/**
+ * GET /ready
+ * Readiness probe — returns 200 only when all dependencies are reachable.
+ * Distinct from GET /health (liveness), which just confirms the process is up.
+ */
+router.get('/', (_req, res) => {
+  const dbState = mongoose.connection.readyState;
+
+  if (dbState !== 1) {
+    res.status(503).json({
+      status: 'not ready',
+      checks: { db: 'disconnected' },
+    });
+    return;
+  }
+
+  res.json({
+    status: 'ready',
+    checks: { db: 'connected' },
+    timestamp: new Date(),
+  });
+});
+
+export const readinessRouter = router;

--- a/apps/api/server.ts
+++ b/apps/api/server.ts
@@ -1,0 +1,54 @@
+import mongoose from 'mongoose';
+
+import { validateApiEnv } from '../../libs/config/src/validateApiEnv';
+import { logger } from './logger';
+import { ensureLocationIndexes } from './models/Location';
+import { shutdownLocationCache } from './services/locationCache';
+import { createApp } from './app';
+
+validateApiEnv();
+
+const PORT = process.env.API_PORT || 4000;
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/qyou';
+
+async function connectDB() {
+  await mongoose.connect(MONGO_URI);
+  await ensureLocationIndexes();
+  logger.info('MongoDB connected');
+}
+
+async function start() {
+  await connectDB();
+
+  const app = createApp();
+
+  const server = app.listen(PORT, () => {
+    logger.info(`API running on http://localhost:${PORT}`);
+  });
+
+  function shutdown() {
+    server.close(async () => {
+      await shutdownLocationCache();
+      await mongoose.disconnect();
+      process.exit(0);
+    });
+  }
+
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+
+  process.on('unhandledRejection', (reason) => {
+    logger.fatal({ err: reason }, 'Unhandled rejection');
+    shutdown();
+  });
+
+  process.on('uncaughtException', (err) => {
+    logger.fatal({ err }, 'Uncaught exception');
+    shutdown();
+  });
+}
+
+start().catch((err) => {
+  logger.fatal({ err }, 'Failed to start server');
+  process.exit(1);
+});

--- a/libs/config/src/validateApiEnv.ts
+++ b/libs/config/src/validateApiEnv.ts
@@ -1,0 +1,17 @@
+import { assertEnv, required, isUrl, oneOf } from './validateEnv';
+
+const API_ENV_SCHEMA = {
+  API_PORT: [required],
+  MONGO_URI: [required, isUrl],
+  JWT_ACCESS_SECRET: [required],
+  JWT_REFRESH_SECRET: [required],
+  STELLAR_NETWORK: [required, oneOf('TESTNET', 'MAINNET')],
+};
+
+/**
+ * Call once at API boot time. Throws with a descriptive message listing every
+ * missing or invalid variable so the process fails fast before accepting traffic.
+ */
+export function validateApiEnv(env = process.env as Record<string, string | undefined>) {
+  assertEnv(API_ENV_SCHEMA, env);
+}


### PR DESCRIPTION
Closes #200, closes #201, closes #202

**#200** — Splits `index.ts` into `app.ts` (Express factory) and `server.ts` (startup/shutdown), making the app importable in tests without binding a port.

**#201** — Adds `validateApiEnv()` in `libs/config/src/validateApiEnv.ts` that calls the existing `assertEnv` helper with the API schema, failing fast at boot if any required variable is missing or malformed.

**#202** — Adds `GET /ready` in `apps/api/routes/readiness.ts` that checks the MongoDB connection state and returns 503 when the DB is not connected, keeping it semantically separate from the liveness `GET /health`.