### PR TITLE
feat(api): response envelope, request-id middleware, error codes, auth schemas

### DIFF
--- a/apps/api/errors/errorCodes.ts
+++ b/apps/api/errors/errorCodes.ts
@@ -1,0 +1,51 @@
+/**
+ * Canonical error codes used across all route handlers.
+ * Keeping them in one place prevents string drift and makes
+ * client-side switch statements exhaustive.
+ */
+export const ErrorCode = {
+  // 400
+  BAD_REQUEST: 'BAD_REQUEST',
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  INVALID_CREDENTIALS: 'INVALID_CREDENTIALS',
+  // 401
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  TOKEN_EXPIRED: 'TOKEN_EXPIRED',
+  TOKEN_INVALID: 'TOKEN_INVALID',
+  // 403
+  FORBIDDEN: 'FORBIDDEN',
+  // 404
+  NOT_FOUND: 'NOT_FOUND',
+  USER_NOT_FOUND: 'USER_NOT_FOUND',
+  LOCATION_NOT_FOUND: 'LOCATION_NOT_FOUND',
+  // 409
+  CONFLICT: 'CONFLICT',
+  EMAIL_TAKEN: 'EMAIL_TAKEN',
+  // 429
+  RATE_LIMITED: 'RATE_LIMITED',
+  // 500
+  INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
+} as const;
+
+export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+/** Maps an ErrorCode to its canonical HTTP status code. */
+export const errorStatusMap: Record<ErrorCode, number> = {
+  BAD_REQUEST: 400,
+  VALIDATION_ERROR: 400,
+  INVALID_CREDENTIALS: 401,
+  UNAUTHORIZED: 401,
+  TOKEN_EXPIRED: 401,
+  TOKEN_INVALID: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  USER_NOT_FOUND: 404,
+  LOCATION_NOT_FOUND: 404,
+  CONFLICT: 409,
+  EMAIL_TAKEN: 409,
+  RATE_LIMITED: 429,
+  INTERNAL_SERVER_ERROR: 500,
+};
+
+export const statusForCode = (code: ErrorCode): number =>
+  errorStatusMap[code] ?? 500;

--- a/apps/api/lib/authSchemas.ts
+++ b/apps/api/lib/authSchemas.ts
@@ -1,0 +1,34 @@
+import { requireEmail, requireString, requireMinLength } from './validation';
+
+export interface LoginInput {
+  email: string;
+  password: string;
+}
+
+export interface RegisterInput {
+  email: string;
+  password: string;
+  name: string;
+}
+
+export interface RefreshInput {
+  refreshToken: string;
+}
+
+/** Validates and normalises a login request body. */
+export const parseLoginInput = (body: Record<string, unknown>): LoginInput => ({
+  email: requireEmail(body.email),
+  password: requireString(body.password, 'password'),
+});
+
+/** Validates and normalises a register request body. */
+export const parseRegisterInput = (body: Record<string, unknown>): RegisterInput => ({
+  email: requireEmail(body.email),
+  password: requireMinLength(requireString(body.password, 'password'), 'password', 8),
+  name: requireMinLength(requireString(body.name, 'name'), 'name', 2),
+});
+
+/** Validates and normalises a token-refresh request body. */
+export const parseRefreshInput = (body: Record<string, unknown>): RefreshInput => ({
+  refreshToken: requireString(body.refreshToken, 'refreshToken'),
+});

--- a/apps/api/lib/responseEnvelope.ts
+++ b/apps/api/lib/responseEnvelope.ts
@@ -1,0 +1,40 @@
+import { Response } from 'express';
+
+export interface SuccessEnvelope<T> {
+  success: true;
+  data: T;
+  meta?: Record<string, unknown>;
+}
+
+export interface ErrorEnvelope {
+  success: false;
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+export const ok = <T>(res: Response, data: T, meta?: Record<string, unknown>, status = 200) =>
+  res.status(status).json({ success: true, data, ...(meta ? { meta } : {}) } satisfies SuccessEnvelope<T>);
+
+export const created = <T>(res: Response, data: T) => ok(res, data, undefined, 201);
+
+export const noContent = (res: Response) => res.status(204).send();
+
+export const fail = (res: Response, status: number, code: string, message: string) =>
+  res.status(status).json({ success: false, error: { code, message } } satisfies ErrorEnvelope);
+
+export const badRequest = (res: Response, message: string, code = 'BAD_REQUEST') =>
+  fail(res, 400, code, message);
+
+export const unauthorized = (res: Response, message = 'Unauthorized', code = 'UNAUTHORIZED') =>
+  fail(res, 401, code, message);
+
+export const forbidden = (res: Response, message = 'Forbidden', code = 'FORBIDDEN') =>
+  fail(res, 403, code, message);
+
+export const notFound = (res: Response, message = 'Not found', code = 'NOT_FOUND') =>
+  fail(res, 404, code, message);
+
+export const serverError = (res: Response, message = 'Internal server error') =>
+  fail(res, 500, 'INTERNAL_SERVER_ERROR', message);

--- a/apps/api/middleware/requestId.ts
+++ b/apps/api/middleware/requestId.ts
@@ -1,0 +1,35 @@
+import { RequestHandler } from 'express';
+import { randomUUID } from 'crypto';
+import { logger } from '../logger';
+
+declare global {
+  namespace Express {
+    interface Request {
+      requestId: string;
+    }
+  }
+}
+
+const REQUEST_ID_HEADER = 'x-request-id';
+
+/**
+ * Attaches a request ID to every incoming request.
+ * Reads `x-request-id` from the incoming headers (e.g. set by a load balancer)
+ * or generates a new UUID. The ID is forwarded in the response header and
+ * bound to the logger child so every log line carries it.
+ */
+export const requestId: RequestHandler = (req, res, next) => {
+  const id = (req.headers[REQUEST_ID_HEADER] as string | undefined) ?? randomUUID();
+
+  req.requestId = id;
+  res.setHeader(REQUEST_ID_HEADER, id);
+
+  // Bind request-scoped logger so downstream code can use req.log
+  (req as unknown as Record<string, unknown>).log = logger.child({ requestId: id });
+
+  next();
+};
+
+/** Pull the request ID off a request, falling back to 'unknown'. */
+export const getRequestId = (req: { requestId?: string }): string =>
+  req.requestId ?? 'unknown';


### PR DESCRIPTION
Adds four backend helpers needed for consistent, traceable API responses:

- **responseEnvelope** (#203) – `ok`, `created`, `fail`, and shorthand helpers (`badRequest`, `notFound`, etc.) so every route returns the same `{ success, data | error }` shape.
- **requestId middleware** (#204) – reads or generates an `x-request-id` UUID per request, forwards it in the response header, and binds a child logger so every log line carries the ID.
- **errorCodes** (#205) – single `ErrorCode` const enum + `errorStatusMap` mapping each code to its HTTP status, eliminating string drift across route handlers.
- **authSchemas** (#206) – `parseLoginInput`, `parseRegisterInput`, and `parseRefreshInput` centralise auth request validation and remove duplicated field checks from the auth route.

Closes #203
Closes #204
Closes #205
Closes #206