### PR TITLE
feat(stellar): harden Stellar client layer

### DIFF
--- a/stellar/client/src/configValidator.ts
+++ b/stellar/client/src/configValidator.ts
@@ -1,0 +1,47 @@
+import { NetworkType } from './config';
+
+export interface ConfigValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+const VALID_NETWORKS: NetworkType[] = ['TESTNET', 'MAINNET'];
+
+const REQUIRED_ENV_KEYS = ['STELLAR_NETWORK'] as const;
+
+export function validateStellarEnv(): ConfigValidationResult {
+  const errors: string[] = [];
+
+  for (const key of REQUIRED_ENV_KEYS) {
+    if (!process.env[key]) {
+      errors.push(`Missing env var: ${key}`);
+    }
+  }
+
+  const network = (process.env.STELLAR_NETWORK || '').toUpperCase() as NetworkType;
+  if (network && !VALID_NETWORKS.includes(network)) {
+    errors.push(`Invalid STELLAR_NETWORK "${network}". Must be TESTNET or MAINNET.`);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function assertValidStellarEnv(): void {
+  const result = validateStellarEnv();
+  if (!result.valid) {
+    throw new Error(`Stellar config validation failed:\n${result.errors.join('\n')}`);
+  }
+}
+
+export function readPositiveEnvNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export function resolveHorizonUrl(network: NetworkType): string {
+  return network === 'MAINNET'
+    ? 'https://horizon.stellar.org'
+    : 'https://horizon-testnet.stellar.org';
+}

--- a/stellar/client/src/networkGuard.ts
+++ b/stellar/client/src/networkGuard.ts
@@ -1,0 +1,47 @@
+import { STELLAR_CONFIG, NetworkType } from './config';
+
+export class NetworkGuard {
+  private static readonly _network: NetworkType = STELLAR_CONFIG.network;
+
+  static isTestnet(): boolean {
+    return this._network === 'TESTNET';
+  }
+
+  static isMainnet(): boolean {
+    return this._network === 'MAINNET';
+  }
+
+  /** Throws if running on mainnet and the caller hasn't explicitly opted in. */
+  static requireTestnet(context: string): void {
+    if (this.isMainnet()) {
+      throw new Error(
+        `[NetworkGuard] "${context}" is only allowed on TESTNET. ` +
+          `Current network: MAINNET.`,
+      );
+    }
+  }
+
+  /** Logs a loud warning before any mainnet write operation. */
+  static warnMainnetWrite(operation: string): void {
+    if (this.isMainnet()) {
+      console.warn(
+        `⚠️  [NetworkGuard] MAINNET write operation: "${operation}". ` +
+          `Ensure this is intentional.`,
+      );
+    }
+  }
+
+  /** Returns a safe label for logging without leaking secrets. */
+  static networkLabel(): string {
+    return this.isMainnet() ? '🔴 MAINNET' : '🟢 TESTNET';
+  }
+
+  /** Asserts the active network matches the expected one. */
+  static assertNetwork(expected: NetworkType): void {
+    if (this._network !== expected) {
+      throw new Error(
+        `[NetworkGuard] Expected ${expected} but running on ${this._network}.`,
+      );
+    }
+  }
+}

--- a/stellar/client/src/txErrors.ts
+++ b/stellar/client/src/txErrors.ts
@@ -1,0 +1,52 @@
+export type TxErrorCode =
+  | 'ACCOUNT_NOT_FOUND'
+  | 'INSUFFICIENT_BALANCE'
+  | 'BAD_SEQUENCE'
+  | 'INVALID_DESTINATION'
+  | 'SUBMISSION_FAILED'
+  | 'NETWORK_ERROR'
+  | 'UNKNOWN';
+
+export interface TxError {
+  code: TxErrorCode;
+  message: string;
+  raw?: unknown;
+}
+
+const RESULT_CODE_MAP: Record<string, TxErrorCode> = {
+  tx_bad_seq: 'BAD_SEQUENCE',
+  op_no_destination: 'INVALID_DESTINATION',
+  op_underfunded: 'INSUFFICIENT_BALANCE',
+  tx_insufficient_balance: 'INSUFFICIENT_BALANCE',
+};
+
+export function mapStellarError(err: unknown): TxError {
+  if (err instanceof Error) {
+    const codes: Record<string, string> | undefined =
+      (err as any).response?.data?.extras?.result_codes;
+
+    if (codes) {
+      const allCodes = [
+        ...(codes.transaction ? [codes.transaction] : []),
+        ...(Array.isArray(codes.operations) ? codes.operations : []),
+      ];
+
+      for (const code of allCodes) {
+        if (RESULT_CODE_MAP[code]) {
+          return { code: RESULT_CODE_MAP[code], message: code, raw: codes };
+        }
+      }
+      return { code: 'SUBMISSION_FAILED', message: JSON.stringify(codes), raw: codes };
+    }
+
+    if (err.message.toLowerCase().includes('not found')) {
+      return { code: 'ACCOUNT_NOT_FOUND', message: err.message };
+    }
+
+    if (err.message.toLowerCase().includes('network') || err.message.toLowerCase().includes('fetch')) {
+      return { code: 'NETWORK_ERROR', message: err.message };
+    }
+  }
+
+  return { code: 'UNKNOWN', message: String(err), raw: err };
+}

--- a/stellar/client/src/walletTypes.ts
+++ b/stellar/client/src/walletTypes.ts
@@ -1,0 +1,51 @@
+import { Keypair } from '@stellar/stellar-sdk';
+
+export interface WalletData {
+  publicKey: string;
+  secret: string;
+}
+
+export type WalletResult =
+  | { ok: true; wallet: WalletData }
+  | { ok: false; error: string };
+
+export function createRandomWallet(): WalletResult {
+  try {
+    const pair = Keypair.random();
+    return {
+      ok: true,
+      wallet: { publicKey: pair.publicKey(), secret: pair.secret() },
+    };
+  } catch (e: any) {
+    return { ok: false, error: e.message };
+  }
+}
+
+export function walletFromSecret(secret: string): WalletResult {
+  if (!secret || typeof secret !== 'string') {
+    return { ok: false, error: 'Secret must be a non-empty string.' };
+  }
+  try {
+    const pair = Keypair.fromSecret(secret);
+    return {
+      ok: true,
+      wallet: { publicKey: pair.publicKey(), secret: pair.secret() },
+    };
+  } catch {
+    return { ok: false, error: 'Invalid Stellar secret key.' };
+  }
+}
+
+export function assertWallet(result: WalletResult): WalletData {
+  if (!result.ok) throw new Error(`Wallet error: ${result.error}`);
+  return result.wallet;
+}
+
+export function isValidPublicKey(key: string): boolean {
+  try {
+    Keypair.fromPublicKey(key);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #231, closes #232, closes #233, closes #234

- **#231** – Extracted config validation and env-reading helpers into `configValidator.ts`, keeping `config.ts` focused on runtime values only.
- **#232** – Added `NetworkGuard` in `networkGuard.ts` with testnet-only assertions and mainnet write warnings to prevent accidental production transactions.
- **#233** – Introduced typed `WalletResult` union and pure wallet helpers in `walletTypes.ts` for predictable, error-safe wallet consumption.
- **#234** – Built `mapStellarError` in `txErrors.ts` that maps Horizon result codes to deterministic `TxErrorCode` values for backend-friendly error handling.