### PR TITLE
feat(stellar): anchor types, memo schema & idempotency keys

### DIFF
--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -162,3 +162,4 @@ export type AdminLocationsListResponse = ApiResponse<AdminLocationsListPayload>;
 export type AdminLocationDetailResponse = ApiResponse<AdminLocationMutationPayload>;
 export type AdminLocationCreateResponse = ApiResponse<AdminLocationMutationPayload>;
 export type AdminLocationUpdateResponse = ApiResponse<AdminLocationMutationPayload>;
+export * from './reputationAnchor';

--- a/libs/types/src/reputationAnchor.ts
+++ b/libs/types/src/reputationAnchor.ts
@@ -1,0 +1,44 @@
+/** Reputation anchor manifest types — issue #239 */
+
+export type AnchorEventKind =
+  | 'REPORT_VERIFIED'
+  | 'BUDDY_COMPLETED'
+  | 'DISPUTE_RESOLVED'
+  | 'REWARD_CLAIMED';
+
+export type AnchorStatus = 'PENDING' | 'ANCHORED' | 'FAILED';
+
+/** A single on-chain reputation anchor record */
+export type ReputationAnchor = {
+  id: string;
+  userId: string;
+  eventKind: AnchorEventKind;
+  referenceId: string;       // e.g. reportId, buddyRequestId
+  scoreImpact: number;       // positive or negative delta
+  status: AnchorStatus;
+  txHash?: string;           // Stellar transaction hash once anchored
+  anchoredAt?: string;       // ISO timestamp
+  createdAt: string;
+};
+
+/** Manifest bundled before a batch anchor submission */
+export type ReputationAnchorManifest = {
+  manifestId: string;
+  userId: string;
+  anchors: ReputationAnchor[];
+  totalScoreImpact: number;
+  createdAt: string;
+};
+
+/** Lightweight summary returned to callers */
+export type ReputationAnchorSummary = {
+  userId: string;
+  currentScore: number;
+  pendingAnchors: number;
+  lastAnchoredAt: string | null;
+};
+
+export type AnchorManifestResponse = {
+  manifest: ReputationAnchorManifest;
+  summary: ReputationAnchorSummary;
+};

--- a/stellar/client/src/idempotency.ts
+++ b/stellar/client/src/idempotency.ts
@@ -1,0 +1,55 @@
+/** Idempotency-key strategy for Stellar submissions — issue #241
+ *
+ * Generates a deterministic key from (userId, kind, referenceId) so the same
+ * logical operation is never submitted twice, even across retries.
+ */
+
+import crypto from 'crypto';
+
+export type IdempotencyRecord = {
+  key: string;
+  txHash?: string;
+  status: 'PENDING' | 'SUBMITTED' | 'FAILED';
+  attempts: number;
+  lastAttemptAt: string;
+};
+
+const store = new Map<string, IdempotencyRecord>();
+
+/** Derive a stable key from the operation's logical identity. */
+export function deriveIdempotencyKey(
+  userId: string,
+  kind: string,
+  referenceId: string,
+): string {
+  return crypto
+    .createHash('sha256')
+    .update(`${userId}:${kind}:${referenceId}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+/** Check whether a key has already been successfully submitted. */
+export function isAlreadySubmitted(key: string): boolean {
+  return store.get(key)?.status === 'SUBMITTED';
+}
+
+/** Record a submission attempt. */
+export function recordAttempt(key: string, txHash?: string): IdempotencyRecord {
+  const existing = store.get(key);
+  const record: IdempotencyRecord = {
+    key,
+    txHash: txHash ?? existing?.txHash,
+    status: txHash ? 'SUBMITTED' : 'PENDING',
+    attempts: (existing?.attempts ?? 0) + 1,
+    lastAttemptAt: new Date().toISOString(),
+  };
+  store.set(key, record);
+  return record;
+}
+
+/** Mark a key as failed so it can be retried. */
+export function markFailed(key: string): void {
+  const rec = store.get(key);
+  if (rec) store.set(key, { ...rec, status: 'FAILED' });
+}

--- a/stellar/client/src/memoSchema.ts
+++ b/stellar/client/src/memoSchema.ts
@@ -1,0 +1,43 @@
+/** Transaction memo schema — issue #240
+ *
+ * Memo format: <kind>:<referenceId>
+ * Max 28 bytes (Stellar TEXT memo limit).
+ * Kinds: RWD=reward, BDY=buddy, ESC=escrow, REP=reputation
+ */
+
+export type MemoKind = 'RWD' | 'BDY' | 'ESC' | 'REP';
+
+const MAX_MEMO_BYTES = 28;
+
+export type ParsedMemo = {
+  kind: MemoKind;
+  referenceId: string;
+};
+
+/** Build a deterministic memo string from kind + referenceId. */
+export function buildMemo(kind: MemoKind, referenceId: string): string {
+  const memo = `${kind}:${referenceId}`;
+  const bytes = Buffer.byteLength(memo, 'utf8');
+  if (bytes > MAX_MEMO_BYTES) {
+    throw new Error(
+      `Memo "${memo}" is ${bytes} bytes — exceeds ${MAX_MEMO_BYTES}-byte limit`,
+    );
+  }
+  return memo;
+}
+
+/** Parse a memo string back into its components. Returns null on invalid format. */
+export function parseMemo(raw: string): ParsedMemo | null {
+  const sep = raw.indexOf(':');
+  if (sep === -1) return null;
+  const kind = raw.slice(0, sep) as MemoKind;
+  const referenceId = raw.slice(sep + 1);
+  if (!['RWD', 'BDY', 'ESC', 'REP'].includes(kind) || !referenceId) return null;
+  return { kind, referenceId };
+}
+
+/** Validate that a memo string conforms to the schema. */
+export function validateMemo(raw: string): boolean {
+  if (Buffer.byteLength(raw, 'utf8') > MAX_MEMO_BYTES) return false;
+  return parseMemo(raw) !== null;
+}


### PR DESCRIPTION
Closes #239, closes #240, closes #241, closes #242

**#239** — Adds `ReputationAnchor`, `ReputationAnchorManifest`, and related types in `libs/types/src/reputationAnchor.ts` to give the reputation-anchoring flow a stable schema before batching work begins.

**#240** — Adds `stellar/client/src/memoSchema.ts` with `buildMemo`, `parseMemo`, and `validateMemo` helpers that enforce the `<kind>:<referenceId>` format and the 28-byte Stellar TEXT memo limit across rewards, payouts, and escrow ops.

**#241** — Adds `stellar/client/src/idempotency.ts` with a SHA-256-derived key strategy and an in-memory store so the same logical Stellar submission is never sent twice across retries.