### PR TITLE
st: reward contracts, persistence boundary & payout-ledger types

### DIFF
--- a/libs/types/src/payout-ledger.ts
+++ b/libs/types/src/payout-ledger.ts
@@ -1,0 +1,50 @@
+// Payout-ledger reference types — shared contracts between backend reward
+// records and Stellar transaction references. Closes #237.
+
+export type PayoutStatus = 'QUEUED' | 'SUBMITTED' | 'CONFIRMED' | 'FAILED';
+
+export type PayoutFailureReason =
+  | 'INSUFFICIENT_BALANCE'
+  | 'STELLAR_SUBMISSION_ERROR'
+  | 'TIMEOUT'
+  | 'INVALID_DESTINATION'
+  | 'UNKNOWN';
+
+/** Immutable reference written to the backend ledger when a payout is initiated. */
+export type PayoutLedgerEntry = {
+  /** Internal backend reward-transaction ID. */
+  rewardTxId: string;
+  /** Stellar transaction hash — populated once submitted to the network. */
+  stellarTxHash: string | null;
+  /** Stellar account that received the payout. */
+  destinationAccount: string;
+  /** Amount in stroops (1 XLM = 10_000_000 stroops). */
+  amountStroops: number;
+  status: PayoutStatus;
+  failureReason?: PayoutFailureReason;
+  /** ISO-8601 timestamp of the last status change. */
+  updatedAt: string;
+};
+
+/** Lightweight reference stored on the RewardTransaction for cross-system tracing. */
+export type StellarPayoutRef = {
+  stellarTxHash: string;
+  ledger: number;
+  /** Memo text echoed from the Stellar transaction. */
+  memo?: string;
+};
+
+/** Result returned by the payout adapter after submission. */
+export type PayoutSubmissionResult =
+  | { ok: true; ref: StellarPayoutRef }
+  | { ok: false; reason: PayoutFailureReason; detail?: string };
+
+/** Query filter for fetching ledger entries by status. */
+export type PayoutLedgerQuery = {
+  userId?: string;
+  status?: PayoutStatus;
+  fromDate?: string;
+  toDate?: string;
+  limit?: number;
+  offset?: number;
+};

--- a/stellar/client/src/reward-persistence.ts
+++ b/stellar/client/src/reward-persistence.ts
@@ -1,0 +1,53 @@
+// Documents the persistence boundary of MockRewardService so local-dev
+// consumers have clear expectations about data durability. Closes #236.
+//
+// PERSISTENCE CONTRACT
+// ────────────────────
+// MockRewardService stores all state in process memory (Map + Array).
+// Data is NOT written to disk, a database, or the Stellar network.
+// Every process restart produces a clean slate — balances and history
+// are lost. This is intentional: the mock exists to let the rest of the
+// app develop without a live Stellar account.
+//
+// Boundary diagram:
+//
+//   ┌─────────────────────────────────────────────────────┐
+//   │  MockRewardService (in-memory)                      │
+//   │  ┌──────────────┐   ┌──────────────────────────┐   │
+//   │  │ balances Map │   │ history RewardTransaction[]│  │
+//   │  └──────────────┘   └──────────────────────────┘   │
+//   │          ↑ lives only for the lifetime of the process│
+//   └─────────────────────────────────────────────────────┘
+//          ✗ MongoDB    ✗ Stellar Horizon    ✗ disk
+
+/** Describes what a persistence-aware reward store must expose. */
+export interface IRewardStore {
+  /** Returns current balance; resolves to 0 for unknown users. */
+  getBalance(userId: string): Promise<number>;
+  /** Appends a transaction and updates the running balance atomically. */
+  recordTransaction(
+    userId: string,
+    delta: number,
+    txId: string,
+    memo?: string,
+  ): Promise<void>;
+  /** Returns all transactions for a user, newest first. */
+  getHistory(userId: string): Promise<StoredRewardTx[]>;
+}
+
+export type StoredRewardTx = {
+  txId: string;
+  userId: string;
+  delta: number;
+  balanceAfter: number;
+  memo?: string;
+  recordedAt: number; // epoch ms
+};
+
+/** Signals that a mock-only operation was attempted in a production context. */
+export class MockBoundaryViolationError extends Error {
+  constructor(op: string) {
+    super(`MockRewardService.${op} must not be called outside local-dev mode.`);
+    this.name = 'MockBoundaryViolationError';
+  }
+}

--- a/stellar/client/src/reward-service-contract.ts
+++ b/stellar/client/src/reward-service-contract.ts
@@ -1,0 +1,53 @@
+// Documents the reward service interface and the responsibilities of each
+// package in the reward pipeline. Closes #235.
+//
+// PACKAGE RESPONSIBILITIES
+// ────────────────────────
+// libs/types          — shared contracts (RewardTransaction, IRewardService)
+//                       No runtime logic; safe to import from any layer.
+// stellar/client      — Stellar adapter: submits payouts to Horizon, maps
+//                       Stellar responses back to shared contracts.
+//                       Never imported by the mobile app directly.
+// apps/api            — orchestrates reward logic; calls IRewardService;
+//                       decides whether to use Mock or Stellar adapter.
+//
+// INTERFACE CONTRACT
+// ──────────────────
+// All reward adapters must satisfy IRewardService (defined in rewards.ts).
+// The mock and the eventual Stellar-backed adapter are interchangeable.
+
+import type { RewardTransaction } from './rewards';
+
+/** Reason a reward operation was rejected before hitting the network. */
+export type RewardOpRejectionReason =
+  | 'INSUFFICIENT_BALANCE'
+  | 'INVALID_AMOUNT'
+  | 'USER_NOT_FOUND'
+  | 'SERVICE_UNAVAILABLE';
+
+/** Typed error thrown by any IRewardService implementation. */
+export class RewardServiceError extends Error {
+  constructor(
+    public readonly reason: RewardOpRejectionReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'RewardServiceError';
+  }
+}
+
+/** Metadata returned alongside a transaction to aid tracing. */
+export type RewardOpResult = {
+  transaction: RewardTransaction;
+  /** True when the operation was handled by the mock adapter. */
+  isMock: boolean;
+  /** Stellar tx hash when settled on-chain; null for mock. */
+  stellarTxHash: string | null;
+};
+
+/**
+ * Factory signature — the API layer calls this to obtain the active adapter.
+ * Swap the return type between MockRewardService and StellarRewardService
+ * without touching call-sites.
+ */
+export type RewardServiceFactory = () => import('./rewards').IRewardService;


### PR DESCRIPTION
Closes #235, closes #236, closes #237

**#237** — Adds `payout-ledger.ts` to `libs/types` with typed references (`PayoutLedgerEntry`, `StellarPayoutRef`, `PayoutSubmissionResult`) that align backend reward records with Stellar transaction hashes.

**#236** — Adds `reward-persistence.ts` to `stellar/client/src` documenting the mock service persistence boundary: in-memory only, no disk/DB/Horizon writes, data resets on restart. Includes `IRewardStore` interface and `MockBoundaryViolationError`.

**#235** — Adds `reward-service-contract.ts` to `stellar/client/src` documenting package responsibilities (libs/types → stellar/client → apps/api) and the typed `RewardServiceFactory` that lets the API layer swap mock vs Stellar adapters without touching call-sites.