### PR TITLE
feat: admin active/stale filters + mobile contract & integration tests

### DIFF
--- a/apps/admin-web/src/app/admin/locations/page.tsx
+++ b/apps/admin-web/src/app/admin/locations/page.tsx
@@ -7,6 +7,7 @@ type SearchParams = {
   dir?: string;
   search?: string;
   type?: string;
+  status?: string;
 };
 
 const toPositiveInt = (v: string | undefined, fallback: number) => {
@@ -27,6 +28,7 @@ export default async function AdminLocationsPage(props: {
       dir={sp.dir === "asc" ? "asc" : "desc"}
       search={sp.search ?? ""}
       type={sp.type ?? ""}
+      status={sp.status ?? ""}
     />
   );
 }

--- a/apps/admin-web/src/components/admin/LocationsDataGrid.tsx
+++ b/apps/admin-web/src/components/admin/LocationsDataGrid.tsx
@@ -30,6 +30,7 @@ type GridProps = {
   dir: "asc" | "desc";
   search: string;
   typeFilter: string;
+  statusFilter: string;
 };
 
 const SORTABLE_FIELDS = new Set(["name", "type", "status", "address", "createdAt"]);
@@ -111,6 +112,7 @@ export default function LocationsDataGrid(props: GridProps) {
       dir: props.dir,
       search: props.search || undefined,
       type: props.typeFilter || undefined,
+      status: props.statusFilter || undefined,
       ...overrides,
     });
   };
@@ -139,6 +141,11 @@ export default function LocationsDataGrid(props: GridProps) {
             <option value="government">Government</option>
             <option value="fuel_station">Fuel Station</option>
             <option value="other">Other</option>
+          </select>
+          <select className={styles.select} name="status" defaultValue={props.statusFilter}>
+            <option value="">All statuses</option>
+            <option value="active">Active</option>
+            <option value="inactive">Stale / Inactive</option>
           </select>
           <button className={styles.filterBtn} type="submit">
             Apply

--- a/apps/admin-web/src/components/admin/LocationsPageServer.tsx
+++ b/apps/admin-web/src/components/admin/LocationsPageServer.tsx
@@ -9,6 +9,7 @@ interface Props {
   dir: "asc" | "desc";
   search: string;
   type: string;
+  status: string;
 }
 
 /**
@@ -23,6 +24,7 @@ export default async function LocationsPageServer({
   dir,
   search,
   type,
+  status,
 }: Props) {
   const cookieStore = await cookies();
   const token = cookieStore.get(process.env.ADMIN_AUTH_COOKIE || "admin_token")?.value ?? "";
@@ -36,6 +38,7 @@ export default async function LocationsPageServer({
     const query = new URLSearchParams({ page: String(page), pageSize: String(pageSize), sort, dir });
     if (search) query.set("search", search);
     if (type) query.set("type", type);
+    if (status) query.set("status", status);
 
     try {
       const res = await fetch(`${apiBase}/admin/locations?${query}`, {
@@ -66,6 +69,7 @@ export default async function LocationsPageServer({
       dir={dir}
       search={search}
       typeFilter={type}
+      statusFilter={status}
     />
   );
 }

--- a/apps/mobile/__tests__/contracts.location-detail.test.ts
+++ b/apps/mobile/__tests__/contracts.location-detail.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Frontend contract tests for location-detail payload normalization (issue #298).
+ * Verifies that LocationDetailsResponse payloads are correctly typed and that
+ * consumers can safely parse detail responses before more UI depends on them.
+ */
+
+import type {
+  LocationDetailsResponse,
+  LocationDetailsItem,
+  QueueSnapshot,
+} from "@/src/network/contracts";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function isSuccess<T>(
+  res: { success: true; data: T } | { success: false; error: unknown }
+): res is { success: true; data: T } {
+  return res.success === true;
+}
+
+function normalizeLocationDetail(res: LocationDetailsResponse): LocationDetailsItem | null {
+  if (!isSuccess(res)) return null;
+  return res.data.item ?? null;
+}
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const snapshot: QueueSnapshot = {
+  locationId: "loc_42",
+  level: "high",
+  estimatedWaitMinutes: 45,
+  reportCount: 7,
+  confidence: 0.9,
+  lastUpdatedAt: "2026-04-29T00:00:00.000Z",
+  isStale: false,
+};
+
+const detailItem: LocationDetailsItem = {
+  _id: "loc_42",
+  name: "General Hospital",
+  type: "hospital",
+  address: "99 Health Ave",
+  status: "active",
+  location: { type: "Point", coordinates: [3.3792, 6.5244] },
+  queueSnapshot: snapshot,
+  createdAt: "2025-01-01T00:00:00.000Z",
+  updatedAt: "2026-04-29T00:00:00.000Z",
+};
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("location-detail contract: success payload", () => {
+  it("normalizes a well-formed success response into a detail item", () => {
+    const res: LocationDetailsResponse = { success: true, data: { item: detailItem } };
+    const result = normalizeLocationDetail(res);
+    expect(result).not.toBeNull();
+    expect(result!._id).toBe("loc_42");
+    expect(result!.name).toBe("General Hospital");
+  });
+
+  it("returns null when item is undefined (location not yet populated)", () => {
+    const res: LocationDetailsResponse = { success: true, data: { item: undefined } };
+    expect(normalizeLocationDetail(res)).toBeNull();
+  });
+
+  it("exposes queueSnapshot when present", () => {
+    const res: LocationDetailsResponse = { success: true, data: { item: detailItem } };
+    const result = normalizeLocationDetail(res);
+    expect(result!.queueSnapshot?.level).toBe("high");
+    expect(result!.queueSnapshot?.isStale).toBe(false);
+  });
+
+  it("handles a stale snapshot correctly", () => {
+    const staleItem: LocationDetailsItem = {
+      ...detailItem,
+      queueSnapshot: { ...snapshot, isStale: true, lastUpdatedAt: null },
+    };
+    const res: LocationDetailsResponse = { success: true, data: { item: staleItem } };
+    const result = normalizeLocationDetail(res);
+    expect(result!.queueSnapshot?.isStale).toBe(true);
+    expect(result!.queueSnapshot?.lastUpdatedAt).toBeNull();
+  });
+
+  it("handles an item without a queueSnapshot", () => {
+    const noSnapshot: LocationDetailsItem = { ...detailItem, queueSnapshot: undefined };
+    const res: LocationDetailsResponse = { success: true, data: { item: noSnapshot } };
+    expect(normalizeLocationDetail(res)!.queueSnapshot).toBeUndefined();
+  });
+
+  it("preserves createdAt and updatedAt timestamps", () => {
+    const res: LocationDetailsResponse = { success: true, data: { item: detailItem } };
+    const result = normalizeLocationDetail(res);
+    expect(result!.createdAt).toBe("2025-01-01T00:00:00.000Z");
+    expect(result!.updatedAt).toBe("2026-04-29T00:00:00.000Z");
+  });
+});
+
+describe("location-detail contract: failure payload", () => {
+  it("returns null for a NOT_FOUND error response", () => {
+    const res: LocationDetailsResponse = {
+      success: false,
+      error: { code: "NOT_FOUND", message: "Location not found" },
+    };
+    expect(normalizeLocationDetail(res)).toBeNull();
+  });
+
+  it("returns null for an internal server error response", () => {
+    const res: LocationDetailsResponse = {
+      success: false,
+      error: { code: "INTERNAL_SERVER_ERROR", message: "Something went wrong" },
+    };
+    expect(normalizeLocationDetail(res)).toBeNull();
+  });
+});

--- a/apps/mobile/__tests__/contracts.nearby-location.test.ts
+++ b/apps/mobile/__tests__/contracts.nearby-location.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Frontend contract tests for nearby-location payload normalization (issue #297).
+ * Verifies that NearbyLocationsResponse payloads are correctly typed and that
+ * consumers can safely parse mixed queue + geo payloads including edge cases.
+ */
+
+import type {
+  NearbyLocationsResponse,
+  NearbyLocationItem,
+  QueueSnapshot,
+} from "@/src/network/contracts";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function isSuccess<T>(
+  res: { success: true; data: T } | { success: false; error: unknown }
+): res is { success: true; data: T } {
+  return res.success === true;
+}
+
+function normalizeNearbyItems(res: NearbyLocationsResponse): NearbyLocationItem[] {
+  if (!isSuccess(res)) return [];
+  return res.data.items ?? [];
+}
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const snapshot: QueueSnapshot = {
+  locationId: "loc_1",
+  level: "medium",
+  estimatedWaitMinutes: 15,
+  reportCount: 3,
+  confidence: 0.8,
+  lastUpdatedAt: "2026-04-29T00:00:00.000Z",
+  isStale: false,
+};
+
+const item: NearbyLocationItem = {
+  _id: "loc_1",
+  name: "City Bank",
+  type: "bank",
+  address: "1 Main St",
+  status: "active",
+  location: { type: "Point", coordinates: [3.3792, 6.5244] },
+  distanceFromUser: 120,
+  queueSnapshot: snapshot,
+};
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("nearby-location contract: success payload", () => {
+  it("normalizes a well-formed success response into an item array", () => {
+    const res: NearbyLocationsResponse = { success: true, data: { items: [item] } };
+    const items = normalizeNearbyItems(res);
+    expect(items).toHaveLength(1);
+    expect(items[0]._id).toBe("loc_1");
+    expect(items[0].queueSnapshot?.level).toBe("medium");
+  });
+
+  it("returns an empty array when items is undefined", () => {
+    const res: NearbyLocationsResponse = { success: true, data: { items: undefined } };
+    expect(normalizeNearbyItems(res)).toEqual([]);
+  });
+
+  it("returns an empty array when items is empty", () => {
+    const res: NearbyLocationsResponse = { success: true, data: { items: [] } };
+    expect(normalizeNearbyItems(res)).toEqual([]);
+  });
+
+  it("preserves distanceFromUser on each item", () => {
+    const res: NearbyLocationsResponse = {
+      success: true,
+      data: { items: [{ ...item, distanceFromUser: 500 }] },
+    };
+    expect(normalizeNearbyItems(res)[0].distanceFromUser).toBe(500);
+  });
+
+  it("handles items without a queueSnapshot (no queue data yet)", () => {
+    const noSnapshot: NearbyLocationItem = { ...item, queueSnapshot: undefined };
+    const res: NearbyLocationsResponse = { success: true, data: { items: [noSnapshot] } };
+    const items = normalizeNearbyItems(res);
+    expect(items[0].queueSnapshot).toBeUndefined();
+  });
+});
+
+describe("nearby-location contract: failure payload", () => {
+  it("returns an empty array for an API error response", () => {
+    const res: NearbyLocationsResponse = {
+      success: false,
+      error: { code: "NOT_FOUND", message: "No locations found" },
+    };
+    expect(normalizeNearbyItems(res)).toEqual([]);
+  });
+
+  it("returns an empty array for an auth error", () => {
+    const res: NearbyLocationsResponse = {
+      success: false,
+      error: { code: "AUTH_ERROR", message: "Unauthorized" },
+    };
+    expect(normalizeNearbyItems(res)).toEqual([]);
+  });
+});

--- a/apps/mobile/__tests__/report-form.integration.test.ts
+++ b/apps/mobile/__tests__/report-form.integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Integration tests for the mobile report form (issue #299).
+ * Tests the submission logic, validation, and state transitions of
+ * ReportComposerModal via the apiClient contract.
+ */
+
+import { apiClient } from "@/src/network/apiClient";
+import type { QueueLevel } from "@qyou/types";
+
+jest.mock("@/src/network/apiClient", () => ({
+  apiClient: {
+    post: jest.fn(),
+  },
+}));
+
+const mockPost = apiClient.post as jest.MockedFunction<typeof apiClient.post>;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+type ReportPayload = {
+  locationId: string;
+  level: QueueLevel;
+  waitTimeMinutes?: number;
+  notes?: string;
+};
+
+/** Mirrors the submit logic in ReportComposerModal */
+async function submitReport(payload: ReportPayload): Promise<"success" | "error"> {
+  try {
+    await apiClient.post("/queues/report", payload);
+    return "success";
+  } catch {
+    return "error";
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── happy path ────────────────────────────────────────────────────────────────
+
+describe("report form: successful submission", () => {
+  it("posts to /queues/report with required fields and returns success", async () => {
+    mockPost.mockResolvedValueOnce({ data: { success: true } } as never);
+
+    const result = await submitReport({ locationId: "loc_1", level: "medium" });
+
+    expect(result).toBe("success");
+    expect(mockPost).toHaveBeenCalledWith("/queues/report", {
+      locationId: "loc_1",
+      level: "medium",
+    });
+  });
+
+  it("includes waitTimeMinutes when provided", async () => {
+    mockPost.mockResolvedValueOnce({ data: { success: true } } as never);
+
+    await submitReport({ locationId: "loc_1", level: "high", waitTimeMinutes: 30 });
+
+    expect(mockPost).toHaveBeenCalledWith("/queues/report", {
+      locationId: "loc_1",
+      level: "high",
+      waitTimeMinutes: 30,
+    });
+  });
+
+  it("includes notes when provided", async () => {
+    mockPost.mockResolvedValueOnce({ data: { success: true } } as never);
+
+    await submitReport({ locationId: "loc_1", level: "low", notes: "Moving fast" });
+
+    expect(mockPost).toHaveBeenCalledWith("/queues/report", {
+      locationId: "loc_1",
+      level: "low",
+      notes: "Moving fast",
+    });
+  });
+
+  it("accepts all valid queue levels", async () => {
+    const levels: QueueLevel[] = ["none", "low", "medium", "high", "unknown"];
+    for (const level of levels) {
+      mockPost.mockResolvedValueOnce({ data: { success: true } } as never);
+      const result = await submitReport({ locationId: "loc_1", level });
+      expect(result).toBe("success");
+    }
+    expect(mockPost).toHaveBeenCalledTimes(levels.length);
+  });
+});
+
+// ── failure / boundary cases ──────────────────────────────────────────────────
+
+describe("report form: submission failure", () => {
+  it("returns error when the API call rejects (network failure)", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Network Error"));
+
+    const result = await submitReport({ locationId: "loc_1", level: "medium" });
+
+    expect(result).toBe("error");
+  });
+
+  it("returns error on a 400 server response", async () => {
+    const err = Object.assign(new Error("Bad Request"), {
+      response: { status: 400, data: { success: false, error: { code: "VALIDATION_ERROR" } } },
+    });
+    mockPost.mockRejectedValueOnce(err);
+
+    const result = await submitReport({ locationId: "loc_1", level: "medium" });
+
+    expect(result).toBe("error");
+  });
+
+  it("returns error on a 401 unauthorized response", async () => {
+    const err = Object.assign(new Error("Unauthorized"), {
+      response: { status: 401 },
+    });
+    mockPost.mockRejectedValueOnce(err);
+
+    const result = await submitReport({ locationId: "loc_1", level: "low" });
+
+    expect(result).toBe("error");
+  });
+});
+
+// ── guard: missing locationId ─────────────────────────────────────────────────
+
+describe("report form: guard conditions", () => {
+  it("does not call the API when locationId is empty", async () => {
+    // Mirrors the `if (!locationId) return;` guard in ReportComposerModal
+    async function submitWithGuard(locationId: string | undefined): Promise<"success" | "error" | "skipped"> {
+      if (!locationId) return "skipped";
+      return submitReport({ locationId, level: "medium" });
+    }
+
+    const result = await submitWithGuard(undefined);
+    expect(result).toBe("skipped");
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("calls the API when locationId is present", async () => {
+    mockPost.mockResolvedValueOnce({ data: { success: true } } as never);
+
+    async function submitWithGuard(locationId: string | undefined): Promise<"success" | "error" | "skipped"> {
+      if (!locationId) return "skipped";
+      return submitReport({ locationId, level: "medium" });
+    }
+
+    const result = await submitWithGuard("loc_99");
+    expect(result).toBe("success");
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #296, 
Closes #297,
Closes #298,
Closes #299

---

### #296 — Admin active/stale location filters

- Added a **Status** filter select (All / Active / Stale-Inactive) to the admin locations toolbar
- `LocationsDataGrid`: new `statusFilter` prop; status `<select>` rendered in the filter form; `withBaseQuery` preserves the param across pagination/sort links
- `LocationsPageServer`: accepts `status` prop and appends it to the API query string
- `page.tsx`: parses `status` from `searchParams` and passes it down

### #297 — Frontend contract tests: nearby-location payload normalization

- `apps/mobile/__tests__/contracts.nearby-location.test.ts` — 7 tests
- Covers: well-formed success, empty/undefined items, missing queueSnapshot, distanceFromUser preservation, NOT_FOUND and AUTH_ERROR failure payloads

### #298 — Frontend contract tests: location-detail payload normalization

- `apps/mobile/__tests__/contracts.location-detail.test.ts` — 8 tests
- Covers: well-formed success, undefined item, stale snapshot (null lastUpdatedAt), missing snapshot, timestamp preservation, NOT_FOUND and INTERNAL_SERVER_ERROR failure payloads

### #299 — Integration tests: mobile report form

- `apps/mobile/__tests__/report-form.integration.test.ts` — 9 tests
- Covers: required-fields POST, optional waitTimeMinutes/notes, all 5 queue levels, network failure, 400/401 server errors, and the `locationId` guard condition

---

### Testing

All new test files follow the Jest mock pattern already established in `apps/mobile/__tests__/auth.test.ts`. No new runtime dependencies introduced.