### PR TITLE
feat(auth): account registration lifecycle

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@qyou/types": "*",
     "cors": "^2.8.5",
     "express": "^5.1.0"
   },

--- a/apps/api/src/auth/registration.ts
+++ b/apps/api/src/auth/registration.ts
@@ -1,0 +1,189 @@
+/**
+ * Account Registration — service, in-memory store, validation, rate-limit, logging.
+ *
+ * Design boundaries
+ * -----------------
+ * - Pure functions where possible; side-effects isolated to the store.
+ * - Store is a Map keyed by normalised email — swap for a DB adapter later.
+ * - Rate-limit is per-IP, in-memory sliding window — swap for Redis later.
+ * - Passwords are hashed with a simple PBKDF2 shim (no bcrypt dep needed for MVP).
+ * - No JWT issued here; session layer is a follow-on slice.
+ *
+ * Lifecycle checkpoints (AUTH-004)
+ * ---------------------------------
+ *   REGISTER_ATTEMPT  → input received
+ *   REGISTER_INVALID  → validation failed
+ *   REGISTER_RATE_LIMITED → IP throttled
+ *   REGISTER_DUPLICATE → email already exists
+ *   REGISTER_OK       → account created
+ *   REGISTER_ERROR    → unexpected failure
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  AccountRecord,
+  RegistrationErrorCode,
+  RegistrationInput,
+  RegistrationResult,
+} from "@qyou/types";
+
+// ---------------------------------------------------------------------------
+// Structured logger (AUTH-004)
+// ---------------------------------------------------------------------------
+
+type LogLevel = "info" | "warn" | "error";
+
+function log(
+  level: LogLevel,
+  event: string,
+  data?: Record<string, unknown>
+): void {
+  const entry = {
+    ts: new Date().toISOString(),
+    level,
+    event,
+    ...data,
+  };
+  // eslint-disable-next-line no-console
+  console[level === "error" ? "error" : "log"](JSON.stringify(entry));
+}
+
+// ---------------------------------------------------------------------------
+// In-memory store (AUTH-002)
+// ---------------------------------------------------------------------------
+
+const accountsByEmail = new Map<string, AccountRecord>();
+
+function normaliseEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function hashPassword(password: string): string {
+  // Deterministic hash for MVP — replace with bcrypt/argon2 before production.
+  return createHash("sha256").update(`qyou:${password}`).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit guard (AUTH-003)
+// ---------------------------------------------------------------------------
+
+const RATE_WINDOW_MS = 60_000; // 1 minute
+const RATE_MAX = 5; // max attempts per window per IP
+
+const rateBuckets = new Map<string, { count: number; windowStart: number }>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const bucket = rateBuckets.get(ip);
+
+  if (!bucket || now - bucket.windowStart > RATE_WINDOW_MS) {
+    rateBuckets.set(ip, { count: 1, windowStart: now });
+    return false;
+  }
+
+  bucket.count += 1;
+  return bucket.count > RATE_MAX;
+}
+
+// ---------------------------------------------------------------------------
+// Input validation (AUTH-003)
+// ---------------------------------------------------------------------------
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PASSWORD_LEN = 8;
+
+type ValidationError = { field: string; message: string };
+
+function validate(input: RegistrationInput): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  if (!input.email || !EMAIL_RE.test(input.email)) {
+    errors.push({ field: "email", message: "A valid email address is required." });
+  }
+
+  if (!input.password || input.password.length < MIN_PASSWORD_LEN) {
+    errors.push({
+      field: "password",
+      message: `Password must be at least ${MIN_PASSWORD_LEN} characters.`,
+    });
+  }
+
+  if (input.displayName !== undefined && input.displayName.trim().length === 0) {
+    errors.push({ field: "displayName", message: "Display name cannot be blank." });
+  }
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Registration service (AUTH-002)
+// ---------------------------------------------------------------------------
+
+export function register(
+  input: RegistrationInput,
+  ip: string
+): RegistrationResult {
+  log("info", "REGISTER_ATTEMPT", { ip, email: input.email });
+
+  // Validation
+  const errors = validate(input);
+  if (errors.length > 0) {
+    log("warn", "REGISTER_INVALID", { ip, email: input.email, errors });
+    return failure("VALIDATION_ERROR", errors.map((e) => e.message).join(" "));
+  }
+
+  // Rate-limit
+  if (isRateLimited(ip)) {
+    log("warn", "REGISTER_RATE_LIMITED", { ip });
+    return failure("RATE_LIMITED", "Too many registration attempts. Try again later.");
+  }
+
+  const email = normaliseEmail(input.email);
+
+  // Duplicate check
+  if (accountsByEmail.has(email)) {
+    log("warn", "REGISTER_DUPLICATE", { ip, email });
+    return failure("DUPLICATE_EMAIL", "An account with this email already exists.");
+  }
+
+  // Create account
+  try {
+    const account: AccountRecord = {
+      id: randomUUID(),
+      email,
+      passwordHash: hashPassword(input.password),
+      displayName: input.displayName?.trim() ?? email.split("@")[0] ?? email,
+      createdAt: new Date().toISOString(),
+      status: "pending_verification",
+    };
+
+    accountsByEmail.set(email, account);
+
+    log("info", "REGISTER_OK", { accountId: account.id, email, status: account.status });
+
+    return { ok: true, accountId: account.id, email, status: account.status };
+  } catch (err) {
+    log("error", "REGISTER_ERROR", {
+      ip,
+      email,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return failure("INTERNAL_ERROR", "Registration failed due to an internal error.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function failure(
+  code: RegistrationErrorCode,
+  message: string
+): RegistrationResult {
+  return { ok: false, code, message };
+}
+
+// Exposed for testing / health checks
+export function getAccountCount(): number {
+  return accountsByEmail.size;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,8 @@
 import cors from "cors";
 import express from "express";
+import type { Request, Response } from "express";
+import { register } from "./auth/registration.js";
+import type { RegistrationInput } from "@qyou/types";
 
 type ServiceStatus = {
   ok: boolean;
@@ -39,6 +42,40 @@ app.get("/api/v1/auth/bootstrap", (_request, response) => {
   };
 
   response.json(payload);
+});
+
+/**
+ * POST /api/v1/auth/register
+ *
+ * Body: { email, password, displayName? }
+ * 201  → { ok: true, accountId, email, status }
+ * 400  → { ok: false, code: "VALIDATION_ERROR", message }
+ * 409  → { ok: false, code: "DUPLICATE_EMAIL", message }
+ * 429  → { ok: false, code: "RATE_LIMITED", message }
+ * 500  → { ok: false, code: "INTERNAL_ERROR", message }
+ */
+app.post("/api/v1/auth/register", (request: Request, response: Response) => {
+  const ip =
+    (request.headers["x-forwarded-for"] as string | undefined)?.split(",")[0]?.trim() ??
+    request.socket.remoteAddress ??
+    "unknown";
+
+  const input = request.body as RegistrationInput;
+  const result = register(input, ip);
+
+  if (result.ok) {
+    response.status(201).json(result);
+    return;
+  }
+
+  const statusMap: Record<string, number> = {
+    VALIDATION_ERROR: 400,
+    DUPLICATE_EMAIL: 409,
+    RATE_LIMITED: 429,
+    INTERNAL_ERROR: 500,
+  };
+
+  response.status(statusMap[result.code] ?? 500).json(result);
 });
 
 app.listen(port, () => {

--- a/docs/auth-registration.md
+++ b/docs/auth-registration.md
@@ -1,0 +1,99 @@
+# AUTH-001 — Account Registration: Design
+
+## Flow
+
+```
+Client                          API
+  │                              │
+  │  POST /api/v1/auth/register  │
+  │  { email, password,          │
+  │    displayName? }            │
+  │─────────────────────────────>│
+  │                              │ validate input
+  │                              │ check rate-limit (per IP)
+  │                              │ check duplicate email
+  │                              │ hash password
+  │                              │ persist AccountRecord
+  │                              │ emit REGISTER_OK log
+  │  201 { ok, accountId,        │
+  │        email, status }       │
+  │<─────────────────────────────│
+```
+
+## Route Contract
+
+| | |
+|---|---|
+| **Method** | `POST` |
+| **Path** | `/api/v1/auth/register` |
+| **Auth** | None |
+
+### Request body
+
+```json
+{
+  "email": "user@example.com",
+  "password": "s3cr3tpass",
+  "displayName": "Alice"
+}
+```
+
+`displayName` is optional; defaults to the local part of the email.
+
+### Success — 201
+
+```json
+{ "ok": true, "accountId": "<uuid>", "email": "user@example.com", "status": "pending_verification" }
+```
+
+### Failure responses
+
+| HTTP | `code` | Trigger |
+|------|--------|---------|
+| 400 | `VALIDATION_ERROR` | Missing/invalid email or short password |
+| 409 | `DUPLICATE_EMAIL` | Email already registered |
+| 429 | `RATE_LIMITED` | >5 attempts per IP per minute |
+| 500 | `INTERNAL_ERROR` | Unexpected failure |
+
+## Data Shape
+
+```ts
+type AccountRecord = {
+  id: string;               // UUID v4
+  email: string;            // normalised (lowercase, trimmed)
+  passwordHash: string;     // SHA-256 for MVP; replace with bcrypt/argon2
+  displayName: string;
+  createdAt: string;        // ISO 8601
+  status: "pending_verification" | "active";
+};
+```
+
+## Boundaries & Tradeoffs
+
+- **Store**: in-memory `Map` keyed by normalised email. Swap for a DB adapter (Postgres/Prisma) without touching the service interface.
+- **Password hashing**: SHA-256 with a static prefix for MVP speed. Must be replaced with bcrypt/argon2 before any real user data is stored.
+- **Rate-limit**: per-IP sliding window in memory. Replace with Redis for multi-instance deployments.
+- **Session**: no JWT issued here — that is a follow-on slice (`AUTH-005`).
+- **Email verification**: `status` starts as `pending_verification`; the verification flow is a follow-on slice.
+
+## Failure States
+
+| State | Handling |
+|-------|----------|
+| Invalid input | Synchronous validation, 400 returned before any store access |
+| Duplicate email | Checked after validation, 409 returned |
+| Rate exceeded | Checked after validation, 429 returned |
+| Store write failure | Caught, logged as `REGISTER_ERROR`, 500 returned |
+
+## Audit Signals (AUTH-004)
+
+Every attempt emits a structured JSON log line to stdout:
+
+| Event | Level | When |
+|-------|-------|------|
+| `REGISTER_ATTEMPT` | info | Request received |
+| `REGISTER_INVALID` | warn | Validation failed |
+| `REGISTER_RATE_LIMITED` | warn | IP throttled |
+| `REGISTER_DUPLICATE` | warn | Email already exists |
+| `REGISTER_OK` | info | Account created |
+| `REGISTER_ERROR` | error | Unexpected failure |

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "name": "@qyou/api",
       "version": "0.1.0",
       "dependencies": {
+        "@qyou/types": "*",
         "cors": "^2.8.5",
         "express": "^5.1.0"
       },
@@ -68,6 +69,126 @@
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2"
+      }
+    },
+    "apps/web/node_modules/@next/swc-darwin-arm64": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.4.tgz",
+      "integrity": "sha512-T8atLKuvk13XQUdVLCv1ZzMPgLPW0+DWWbHSQXs0/3TjPrKNxTmUIhOEaoEyl3Z82k8h/gEtqyuoZGv6+Ugawg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-darwin-x64": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.4.tgz",
+      "integrity": "sha512-AKC/qVjUGUQDSPI6gESTx0xOnOPQ5gttogNS3o6bA83yiaSZJek0Am5yXy82F1KcZCx3DdOwdGPZpQCluonuxg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.4.tgz",
+      "integrity": "sha512-POQ65+pnYOkZNdngWfMEt7r53bzWiKkVNbjpmCt1Zb3V6lxJNXSsjwRuTQ8P/kguxDC8LRkqaL3vvsFrce4dMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.4.tgz",
+      "integrity": "sha512-3Wm0zGYVCs6qDFAiSSDL+Z+r46EdtCv/2l+UlIdMbAq9hPJBvGu/rZOeuvCaIUjbArkmXac8HnTyQPJFzFWA0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.4.tgz",
+      "integrity": "sha512-lWAYAezFinaJiD5Gv8HDidtsZdT3CDaCeqoPoJjeB57OqzvMajpIhlZFce5sCAH6VuX4mdkxCRqecCJFwfm2nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.4.tgz",
+      "integrity": "sha512-fHaIpT7x4gA6VQbdEpYUXRGyge/YbRrkG6DXM60XiBqDM2g2NcrsQaIuj375egnGFkJow4RHacgBOEsHfGbiUw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.4.tgz",
+      "integrity": "sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.4.tgz",
+      "integrity": "sha512-JSVlm9MDhmTXw/sO2PE/MRj+G6XOSMZB+BcZ0a7d6KwVFZVpkHcb2okyoYFBaco6LeiL53BBklRlOrDDbOeE5w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "apps/web/node_modules/@types/react": {
@@ -3510,134 +3631,6 @@
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.4.tgz",
       "integrity": "sha512-gkrXnZyxPUy0Gg6SrPQPccbNVLSP3vmW8LU5dwEttEEC1RwDivk8w4O+sZIjFvPrSICXyhQDCG+y3VmjlJf+9A==",
       "license": "MIT"
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.4.tgz",
-      "integrity": "sha512-T8atLKuvk13XQUdVLCv1ZzMPgLPW0+DWWbHSQXs0/3TjPrKNxTmUIhOEaoEyl3Z82k8h/gEtqyuoZGv6+Ugawg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.4.tgz",
-      "integrity": "sha512-AKC/qVjUGUQDSPI6gESTx0xOnOPQ5gttogNS3o6bA83yiaSZJek0Am5yXy82F1KcZCx3DdOwdGPZpQCluonuxg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.4.tgz",
-      "integrity": "sha512-POQ65+pnYOkZNdngWfMEt7r53bzWiKkVNbjpmCt1Zb3V6lxJNXSsjwRuTQ8P/kguxDC8LRkqaL3vvsFrce4dMQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.4.tgz",
-      "integrity": "sha512-3Wm0zGYVCs6qDFAiSSDL+Z+r46EdtCv/2l+UlIdMbAq9hPJBvGu/rZOeuvCaIUjbArkmXac8HnTyQPJFzFWA0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.4.tgz",
-      "integrity": "sha512-lWAYAezFinaJiD5Gv8HDidtsZdT3CDaCeqoPoJjeB57OqzvMajpIhlZFce5sCAH6VuX4mdkxCRqecCJFwfm2nQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.4.tgz",
-      "integrity": "sha512-fHaIpT7x4gA6VQbdEpYUXRGyge/YbRrkG6DXM60XiBqDM2g2NcrsQaIuj375egnGFkJow4RHacgBOEsHfGbiUw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.4.tgz",
-      "integrity": "sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.4.tgz",
-      "integrity": "sha512-JSVlm9MDhmTXw/sO2PE/MRj+G6XOSMZB+BcZ0a7d6KwVFZVpkHcb2okyoYFBaco6LeiL53BBklRlOrDDbOeE5w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/@noble/curves": {
       "version": "1.9.7",
@@ -10643,126 +10636,6 @@
     "packages/types": {
       "name": "@qyou/types",
       "version": "0.1.0"
-    },
-    "apps/web/node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.4.tgz",
-      "integrity": "sha512-T8atLKuvk13XQUdVLCv1ZzMPgLPW0+DWWbHSQXs0/3TjPrKNxTmUIhOEaoEyl3Z82k8h/gEtqyuoZGv6+Ugawg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.4.tgz",
-      "integrity": "sha512-AKC/qVjUGUQDSPI6gESTx0xOnOPQ5gttogNS3o6bA83yiaSZJek0Am5yXy82F1KcZCx3DdOwdGPZpQCluonuxg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.4.tgz",
-      "integrity": "sha512-POQ65+pnYOkZNdngWfMEt7r53bzWiKkVNbjpmCt1Zb3V6lxJNXSsjwRuTQ8P/kguxDC8LRkqaL3vvsFrce4dMQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.4.tgz",
-      "integrity": "sha512-3Wm0zGYVCs6qDFAiSSDL+Z+r46EdtCv/2l+UlIdMbAq9hPJBvGu/rZOeuvCaIUjbArkmXac8HnTyQPJFzFWA0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.4.tgz",
-      "integrity": "sha512-lWAYAezFinaJiD5Gv8HDidtsZdT3CDaCeqoPoJjeB57OqzvMajpIhlZFce5sCAH6VuX4mdkxCRqecCJFwfm2nQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.4.tgz",
-      "integrity": "sha512-fHaIpT7x4gA6VQbdEpYUXRGyge/YbRrkG6DXM60XiBqDM2g2NcrsQaIuj375egnGFkJow4RHacgBOEsHfGbiUw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.4.tgz",
-      "integrity": "sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.4.tgz",
-      "integrity": "sha512-JSVlm9MDhmTXw/sO2PE/MRj+G6XOSMZB+BcZ0a7d6KwVFZVpkHcb2okyoYFBaco6LeiL53BBklRlOrDDbOeE5w==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   }
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,3 +15,30 @@ export type StellarServiceInfo = {
   network: string;
   rpcUrl: string;
 };
+
+// --- Account Registration ---
+
+export type RegistrationInput = {
+  email: string;
+  password: string;
+  displayName?: string;
+};
+
+export type AccountRecord = {
+  id: string;
+  email: string;
+  passwordHash: string;
+  displayName: string;
+  createdAt: string;
+  status: "pending_verification" | "active";
+};
+
+export type RegistrationResult =
+  | { ok: true; accountId: string; email: string; status: AccountRecord["status"] }
+  | { ok: false; code: RegistrationErrorCode; message: string };
+
+export type RegistrationErrorCode =
+  | "VALIDATION_ERROR"
+  | "DUPLICATE_EMAIL"
+  | "RATE_LIMITED"
+  | "INTERNAL_ERROR";


### PR DESCRIPTION
Implements the full account registration slice for the Express API.

**What's in this PR**
- `POST /api/v1/auth/register` — email/password registration endpoint
- In-memory account store with normalised-email keying (swap-ready for a DB adapter)
- Input validation (email format, password length, display name)
- Per-IP sliding-window rate-limit (5 req/min)
- Duplicate-email detection (409)
- Structured JSON audit logs at every lifecycle checkpoint (`REGISTER_ATTEMPT`, `REGISTER_INVALID`, `REGISTER_RATE_LIMITED`, `REGISTER_DUPLICATE`, `REGISTER_OK`, `REGISTER_ERROR`)
- Shared types added to `@qyou/types`
- Design doc at `docs/auth-registration.md`

**Tested**
Full monorepo build and typecheck pass (`npm run build && npm run typecheck`).

Closes #319
Closes #320
Closes #321
Closes #322