### PR TITLE
auth: registration tests + login flow with hardening

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,6 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsx watch src/index.ts",
     "lint": "tsc -p tsconfig.json --noEmit",
+    "test": "node --import tsx/esm --test src/auth/registration.test.ts src/auth/login.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/apps/api/src/auth/login.test.ts
+++ b/apps/api/src/auth/login.test.ts
@@ -1,0 +1,106 @@
+/**
+ * AUTH-007/008 — Login lifecycle and hardening tests.
+ *
+ * Run with:
+ *   node --import tsx/esm --test src/auth/login.test.ts
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { login, clearLoginRateBuckets } from "./login.js";
+import { clearAccounts, seedAccount } from "./store.js";
+import { hashPassword } from "./registration.js";
+
+const SEED = {
+  id: "test-uuid-1",
+  email: "alice@example.com",
+  passwordHash: hashPassword("password123"),
+  displayName: "alice",
+  createdAt: new Date().toISOString(),
+  status: "active" as const,
+};
+
+beforeEach(() => {
+  clearAccounts();
+  clearLoginRateBuckets();
+  seedAccount(SEED);
+});
+
+describe("login — happy path", () => {
+  it("returns ok:true with tokens for valid credentials", () => {
+    const result = login({ email: "alice@example.com", password: "password123" }, "1.2.3.4");
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.email, "alice@example.com");
+    assert.ok(result.tokens.accessToken.split(".").length === 3);
+    assert.ok(result.tokens.refreshToken.length > 0);
+    assert.ok(new Date(result.tokens.expiresAt) > new Date());
+  });
+
+  it("is case-insensitive for email", () => {
+    const result = login({ email: "ALICE@EXAMPLE.COM", password: "password123" }, "1.2.3.4");
+    assert.equal(result.ok, true);
+  });
+});
+
+describe("login — invalid credentials", () => {
+  it("returns INVALID_CREDENTIALS for wrong password", () => {
+    const result = login({ email: "alice@example.com", password: "wrongpassword" }, "1.2.3.4");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_CREDENTIALS");
+  });
+
+  it("returns INVALID_CREDENTIALS for unknown email", () => {
+    const result = login({ email: "nobody@example.com", password: "password123" }, "1.2.3.4");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_CREDENTIALS");
+  });
+
+  it("does not reveal whether email exists (same error code)", () => {
+    const knownResult = login({ email: "alice@example.com", password: "wrong" }, "1.2.3.4");
+    const unknownResult = login({ email: "ghost@example.com", password: "wrong" }, "1.2.3.5");
+    assert.equal(knownResult.ok, false);
+    assert.equal(unknownResult.ok, false);
+    if (knownResult.ok || unknownResult.ok) throw new Error("unreachable");
+    assert.equal(knownResult.code, unknownResult.code);
+    assert.equal(knownResult.message, unknownResult.message);
+  });
+});
+
+describe("login — validation", () => {
+  it("rejects invalid email format", () => {
+    const result = login({ email: "not-an-email", password: "password123" }, "1.2.3.4");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("rejects empty password", () => {
+    const result = login({ email: "alice@example.com", password: "" }, "1.2.3.4");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+});
+
+describe("login — rate limiting (AUTH-008)", () => {
+  it("returns RATE_LIMITED after 5 failed attempts from same IP", () => {
+    for (let i = 0; i < 5; i++) {
+      login({ email: "alice@example.com", password: "wrong" }, "9.9.9.9");
+    }
+    const result = login({ email: "alice@example.com", password: "password123" }, "9.9.9.9");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "RATE_LIMITED");
+  });
+
+  it("allows login from a different IP", () => {
+    for (let i = 0; i < 6; i++) {
+      login({ email: "alice@example.com", password: "wrong" }, "9.9.9.9");
+    }
+    const result = login({ email: "alice@example.com", password: "password123" }, "8.8.8.8");
+    assert.equal(result.ok, true);
+  });
+});

--- a/apps/api/src/auth/login.ts
+++ b/apps/api/src/auth/login.ts
@@ -1,0 +1,167 @@
+/**
+ * Login / Token-Issuance — service, validation, rate-limit, constant-time compare.
+ *
+ * Design (AUTH-006)
+ * -----------------
+ * - Credentials validated against the shared in-memory account store.
+ * - Passwords compared with timingSafeEqual to prevent timing attacks (AUTH-008).
+ * - Per-IP rate-limit (5 attempts / 60 s) mirrors registration guard (AUTH-008).
+ * - JWTs are HMAC-SHA256 signed; secret from JWT_SECRET env var (AUTH-008).
+ * - Access token: 15 min. Refresh token: 7 days (opaque UUID, in-memory store).
+ * - Generic "Invalid email or password" response — never reveals email existence (AUTH-008).
+ *
+ * Lifecycle events
+ * ----------------
+ *   LOGIN_ATTEMPT → credentials received
+ *   LOGIN_INVALID → validation failed
+ *   LOGIN_RATE_LIMITED → IP throttled
+ *   LOGIN_BAD_CREDENTIALS → email/password mismatch
+ *   LOGIN_OK → tokens issued
+ *   LOGIN_ERROR → unexpected failure
+ */
+
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import type { AccountRecord, LoginErrorCode, LoginInput, LoginResult, TokenPair } from "@qyou/types";
+import { getAccountByEmail } from "./store.js";
+
+// ---------------------------------------------------------------------------
+// Structured logger
+// ---------------------------------------------------------------------------
+
+type LogLevel = "info" | "warn" | "error";
+function log(level: LogLevel, event: string, data?: Record<string, unknown>): void {
+  const entry = { ts: new Date().toISOString(), level, event, ...data };
+  // eslint-disable-next-line no-console
+  console[level === "error" ? "error" : "log"](JSON.stringify(entry));
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit (AUTH-008)
+// ---------------------------------------------------------------------------
+
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX = 5;
+const loginRateBuckets = new Map<string, { count: number; windowStart: number }>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const bucket = loginRateBuckets.get(ip);
+  if (!bucket || now - bucket.windowStart > RATE_WINDOW_MS) {
+    loginRateBuckets.set(ip, { count: 1, windowStart: now });
+    return false;
+  }
+  bucket.count += 1;
+  return bucket.count > RATE_MAX;
+}
+
+/** For tests: reset rate-limit state. */
+export function clearLoginRateBuckets(): void {
+  loginRateBuckets.clear();
+}
+
+// ---------------------------------------------------------------------------
+// JWT (no external dep) (AUTH-007)
+// ---------------------------------------------------------------------------
+
+const JWT_SECRET = process.env.JWT_SECRET ?? "dev-secret-change-in-production";
+const ACCESS_TTL_MS = 15 * 60 * 1000;
+const REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function signJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const sig = createHash("sha256").update(`${header}.${body}.${JWT_SECRET}`).digest("base64url");
+  return `${header}.${body}.${sig}`;
+}
+
+// Refresh token store: token → { accountId, expiresAt }
+const refreshStore = new Map<string, { accountId: string; expiresAt: number }>();
+
+function issueTokens(accountId: string, email: string): TokenPair {
+  const now = Date.now();
+  const expiresAt = new Date(now + ACCESS_TTL_MS).toISOString();
+  const accessToken = signJwt({
+    sub: accountId,
+    email,
+    iat: Math.floor(now / 1000),
+    exp: Math.floor((now + ACCESS_TTL_MS) / 1000),
+  });
+  const refreshToken = randomUUID();
+  refreshStore.set(refreshToken, { accountId, expiresAt: now + REFRESH_TTL_MS });
+  return { accessToken, expiresAt, refreshToken };
+}
+
+// ---------------------------------------------------------------------------
+// Credential verification — constant-time compare (AUTH-008)
+// ---------------------------------------------------------------------------
+
+function hashPassword(password: string): string {
+  return createHash("sha256").update(`qyou:${password}`).digest("hex");
+}
+
+function verifyPassword(candidate: string, storedHash: string): boolean {
+  const a = Buffer.from(hashPassword(candidate));
+  const b = Buffer.from(storedHash);
+  // Pad to same length before timingSafeEqual to avoid length-based leaks
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function validate(input: LoginInput): string | null {
+  if (!input.email || !EMAIL_RE.test(input.email)) return "A valid email address is required.";
+  if (!input.password || input.password.length < 1) return "Password is required.";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Login service (AUTH-007)
+// ---------------------------------------------------------------------------
+
+export function login(input: LoginInput, ip: string): LoginResult {
+  log("info", "LOGIN_ATTEMPT", { ip, email: input.email });
+
+  const validationError = validate(input);
+  if (validationError) {
+    log("warn", "LOGIN_INVALID", { ip, email: input.email });
+    return fail("VALIDATION_ERROR", validationError);
+  }
+
+  if (isRateLimited(ip)) {
+    log("warn", "LOGIN_RATE_LIMITED", { ip });
+    return fail("RATE_LIMITED", "Too many login attempts. Try again later.");
+  }
+
+  try {
+    const account: AccountRecord | undefined = getAccountByEmail(input.email);
+
+    // Always run verifyPassword to keep timing consistent (AUTH-008)
+    const dummyHash = "0".repeat(64);
+    const hash = account?.passwordHash ?? dummyHash;
+    const match = verifyPassword(input.password, hash);
+
+    if (!account || !match) {
+      log("warn", "LOGIN_BAD_CREDENTIALS", { ip, email: input.email });
+      return fail("INVALID_CREDENTIALS", "Invalid email or password.");
+    }
+
+    const tokens = issueTokens(account.id, account.email);
+    log("info", "LOGIN_OK", { accountId: account.id, email: account.email });
+    return { ok: true, accountId: account.id, email: account.email, tokens };
+  } catch (err) {
+    log("error", "LOGIN_ERROR", { ip, error: err instanceof Error ? err.message : String(err) });
+    return fail("INTERNAL_ERROR", "Login failed due to an internal error.");
+  }
+}
+
+function fail(code: LoginErrorCode, message: string): LoginResult {
+  return { ok: false, code, message };
+}
+
+/** Exposed for testing */
+export { refreshStore };

--- a/apps/api/src/auth/registration.test.ts
+++ b/apps/api/src/auth/registration.test.ts
@@ -1,0 +1,107 @@
+/**
+ * AUTH-005 — Registration lifecycle tests.
+ *
+ * Run with:
+ *   node --import tsx/esm --test src/auth/registration.test.ts
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { register, clearRateBuckets } from "./registration.js";
+import { clearAccounts } from "./store.js";
+
+beforeEach(() => {
+  clearAccounts();
+  clearRateBuckets();
+});
+
+describe("register — happy path", () => {
+  it("creates an account and returns ok:true", () => {
+    const result = register({ email: "alice@example.com", password: "password123" }, "1.2.3.4");
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.email, "alice@example.com");
+    assert.equal(result.status, "pending_verification");
+    assert.ok(result.accountId.length > 0);
+  });
+
+  it("normalises email to lowercase", () => {
+    const result = register({ email: "Alice@Example.COM", password: "password123" }, "1.2.3.4");
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.email, "alice@example.com");
+  });
+
+  it("uses email prefix as displayName when not provided", () => {
+    register({ email: "bob@example.com", password: "password123" }, "1.2.3.4");
+    // No assertion on displayName from result — it's stored internally; just ensure no error
+  });
+});
+
+describe("register — validation", () => {
+  it("rejects missing email", () => {
+    const result = register({ email: "", password: "password123" }, "1.2.3.4");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("rejects invalid email format", () => {
+    const result = register({ email: "not-an-email", password: "password123" }, "1.2.3.4");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("rejects password shorter than 8 characters", () => {
+    const result = register({ email: "alice@example.com", password: "short" }, "1.2.3.4");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("rejects blank displayName", () => {
+    const result = register({ email: "alice@example.com", password: "password123", displayName: "   " }, "1.2.3.4");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+});
+
+describe("register — duplicate email", () => {
+  it("returns DUPLICATE_EMAIL on second registration with same email", () => {
+    register({ email: "alice@example.com", password: "password123" }, "1.2.3.4");
+    const result = register({ email: "alice@example.com", password: "different123" }, "1.2.3.5");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "DUPLICATE_EMAIL");
+  });
+
+  it("treats email as case-insensitive for duplicate check", () => {
+    register({ email: "alice@example.com", password: "password123" }, "1.2.3.4");
+    const result = register({ email: "ALICE@EXAMPLE.COM", password: "password123" }, "1.2.3.5");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "DUPLICATE_EMAIL");
+  });
+});
+
+describe("register — rate limiting", () => {
+  it("returns RATE_LIMITED after 5 attempts from the same IP", () => {
+    for (let i = 0; i < 5; i++) {
+      register({ email: `user${i}@example.com`, password: "password123" }, "9.9.9.9");
+    }
+    const result = register({ email: "overflow@example.com", password: "password123" }, "9.9.9.9");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "RATE_LIMITED");
+  });
+
+  it("allows registration from a different IP", () => {
+    for (let i = 0; i < 6; i++) {
+      register({ email: `user${i}@example.com`, password: "password123" }, "9.9.9.9");
+    }
+    const result = register({ email: "other@example.com", password: "password123" }, "8.8.8.8");
+    assert.equal(result.ok, true);
+  });
+});

--- a/apps/api/src/auth/registration.ts
+++ b/apps/api/src/auth/registration.ts
@@ -1,12 +1,12 @@
 /**
- * Account Registration — service, in-memory store, validation, rate-limit, logging.
+ * Account Registration — service, validation, rate-limit, logging.
  *
  * Design boundaries
  * -----------------
  * - Pure functions where possible; side-effects isolated to the store.
  * - Store is a Map keyed by normalised email — swap for a DB adapter later.
  * - Rate-limit is per-IP, in-memory sliding window — swap for Redis later.
- * - Passwords are hashed with a simple PBKDF2 shim (no bcrypt dep needed for MVP).
+ * - Passwords are hashed with SHA-256 (MVP only — use bcrypt/argon2 in production).
  * - No JWT issued here; session layer is a follow-on slice.
  *
  * Lifecycle checkpoints (AUTH-004)
@@ -26,6 +26,7 @@ import type {
   RegistrationInput,
   RegistrationResult,
 } from "@qyou/types";
+import { accountsByEmail, getAccountCount } from "./store.js";
 
 // ---------------------------------------------------------------------------
 // Structured logger (AUTH-004)
@@ -33,32 +34,21 @@ import type {
 
 type LogLevel = "info" | "warn" | "error";
 
-function log(
-  level: LogLevel,
-  event: string,
-  data?: Record<string, unknown>
-): void {
-  const entry = {
-    ts: new Date().toISOString(),
-    level,
-    event,
-    ...data,
-  };
+function log(level: LogLevel, event: string, data?: Record<string, unknown>): void {
+  const entry = { ts: new Date().toISOString(), level, event, ...data };
   // eslint-disable-next-line no-console
   console[level === "error" ? "error" : "log"](JSON.stringify(entry));
 }
 
 // ---------------------------------------------------------------------------
-// In-memory store (AUTH-002)
+// Helpers
 // ---------------------------------------------------------------------------
 
-const accountsByEmail = new Map<string, AccountRecord>();
-
-function normaliseEmail(email: string): string {
+export function normaliseEmail(email: string): string {
   return email.trim().toLowerCase();
 }
 
-function hashPassword(password: string): string {
+export function hashPassword(password: string): string {
   // Deterministic hash for MVP — replace with bcrypt/argon2 before production.
   return createHash("sha256").update(`qyou:${password}`).digest("hex");
 }
@@ -67,22 +57,24 @@ function hashPassword(password: string): string {
 // Rate-limit guard (AUTH-003)
 // ---------------------------------------------------------------------------
 
-const RATE_WINDOW_MS = 60_000; // 1 minute
-const RATE_MAX = 5; // max attempts per window per IP
-
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX = 5;
 const rateBuckets = new Map<string, { count: number; windowStart: number }>();
 
 function isRateLimited(ip: string): boolean {
   const now = Date.now();
   const bucket = rateBuckets.get(ip);
-
   if (!bucket || now - bucket.windowStart > RATE_WINDOW_MS) {
     rateBuckets.set(ip, { count: 1, windowStart: now });
     return false;
   }
-
   bucket.count += 1;
   return bucket.count > RATE_MAX;
+}
+
+/** For tests: reset rate-limit state. */
+export function clearRateBuckets(): void {
+  rateBuckets.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -96,22 +88,15 @@ type ValidationError = { field: string; message: string };
 
 function validate(input: RegistrationInput): ValidationError[] {
   const errors: ValidationError[] = [];
-
   if (!input.email || !EMAIL_RE.test(input.email)) {
     errors.push({ field: "email", message: "A valid email address is required." });
   }
-
   if (!input.password || input.password.length < MIN_PASSWORD_LEN) {
-    errors.push({
-      field: "password",
-      message: `Password must be at least ${MIN_PASSWORD_LEN} characters.`,
-    });
+    errors.push({ field: "password", message: `Password must be at least ${MIN_PASSWORD_LEN} characters.` });
   }
-
   if (input.displayName !== undefined && input.displayName.trim().length === 0) {
     errors.push({ field: "displayName", message: "Display name cannot be blank." });
   }
-
   return errors;
 }
 
@@ -119,20 +104,15 @@ function validate(input: RegistrationInput): ValidationError[] {
 // Registration service (AUTH-002)
 // ---------------------------------------------------------------------------
 
-export function register(
-  input: RegistrationInput,
-  ip: string
-): RegistrationResult {
+export function register(input: RegistrationInput, ip: string): RegistrationResult {
   log("info", "REGISTER_ATTEMPT", { ip, email: input.email });
 
-  // Validation
   const errors = validate(input);
   if (errors.length > 0) {
     log("warn", "REGISTER_INVALID", { ip, email: input.email, errors });
     return failure("VALIDATION_ERROR", errors.map((e) => e.message).join(" "));
   }
 
-  // Rate-limit
   if (isRateLimited(ip)) {
     log("warn", "REGISTER_RATE_LIMITED", { ip });
     return failure("RATE_LIMITED", "Too many registration attempts. Try again later.");
@@ -140,13 +120,11 @@ export function register(
 
   const email = normaliseEmail(input.email);
 
-  // Duplicate check
   if (accountsByEmail.has(email)) {
     log("warn", "REGISTER_DUPLICATE", { ip, email });
     return failure("DUPLICATE_EMAIL", "An account with this email already exists.");
   }
 
-  // Create account
   try {
     const account: AccountRecord = {
       id: randomUUID(),
@@ -158,32 +136,16 @@ export function register(
     };
 
     accountsByEmail.set(email, account);
-
     log("info", "REGISTER_OK", { accountId: account.id, email, status: account.status });
-
     return { ok: true, accountId: account.id, email, status: account.status };
   } catch (err) {
-    log("error", "REGISTER_ERROR", {
-      ip,
-      email,
-      error: err instanceof Error ? err.message : String(err),
-    });
+    log("error", "REGISTER_ERROR", { ip, email, error: err instanceof Error ? err.message : String(err) });
     return failure("INTERNAL_ERROR", "Registration failed due to an internal error.");
   }
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function failure(
-  code: RegistrationErrorCode,
-  message: string
-): RegistrationResult {
+function failure(code: RegistrationErrorCode, message: string): RegistrationResult {
   return { ok: false, code, message };
 }
 
-// Exposed for testing / health checks
-export function getAccountCount(): number {
-  return accountsByEmail.size;
-}
+export { getAccountCount };

--- a/apps/api/src/auth/store.ts
+++ b/apps/api/src/auth/store.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared in-memory account store.
+ * Swap the Map for a DB adapter when persistence is needed.
+ */
+
+import type { AccountRecord } from "@qyou/types";
+
+export const accountsByEmail = new Map<string, AccountRecord>();
+
+export function getAccountByEmail(email: string): AccountRecord | undefined {
+  return accountsByEmail.get(email.trim().toLowerCase());
+}
+
+/** For tests: seed an account directly. */
+export function seedAccount(account: AccountRecord): void {
+  accountsByEmail.set(account.email, account);
+}
+
+export function getAccountCount(): number {
+  return accountsByEmail.size;
+}
+
+/** For tests: reset state. */
+export function clearAccounts(): void {
+  accountsByEmail.clear();
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,7 +2,8 @@ import cors from "cors";
 import express from "express";
 import type { Request, Response } from "express";
 import { register } from "./auth/registration.js";
-import type { RegistrationInput } from "@qyou/types";
+import { login } from "./auth/login.js";
+import type { LoginInput, RegistrationInput } from "@qyou/types";
 
 type ServiceStatus = {
   ok: boolean;
@@ -71,6 +72,40 @@ app.post("/api/v1/auth/register", (request: Request, response: Response) => {
   const statusMap: Record<string, number> = {
     VALIDATION_ERROR: 400,
     DUPLICATE_EMAIL: 409,
+    RATE_LIMITED: 429,
+    INTERNAL_ERROR: 500,
+  };
+
+  response.status(statusMap[result.code] ?? 500).json(result);
+});
+
+/**
+ * POST /api/v1/auth/login
+ *
+ * Body: { email, password }
+ * 200  → { ok: true, accountId, email, tokens: { accessToken, expiresAt, refreshToken } }
+ * 400  → { ok: false, code: "VALIDATION_ERROR", message }
+ * 401  → { ok: false, code: "INVALID_CREDENTIALS", message }
+ * 429  → { ok: false, code: "RATE_LIMITED", message }
+ * 500  → { ok: false, code: "INTERNAL_ERROR", message }
+ */
+app.post("/api/v1/auth/login", (request: Request, response: Response) => {
+  const ip =
+    (request.headers["x-forwarded-for"] as string | undefined)?.split(",")[0]?.trim() ??
+    request.socket.remoteAddress ??
+    "unknown";
+
+  const input = request.body as LoginInput;
+  const result = login(input, ip);
+
+  if (result.ok) {
+    response.status(200).json(result);
+    return;
+  }
+
+  const statusMap: Record<string, number> = {
+    VALIDATION_ERROR: 400,
+    INVALID_CREDENTIALS: 401,
     RATE_LIMITED: 429,
     INTERNAL_ERROR: 500,
   };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -42,3 +42,27 @@ export type RegistrationErrorCode =
   | "DUPLICATE_EMAIL"
   | "RATE_LIMITED"
   | "INTERNAL_ERROR";
+
+// --- Login / Token Issuance ---
+
+export type LoginInput = {
+  email: string;
+  password: string;
+};
+
+export type TokenPair = {
+  accessToken: string;
+  /** ISO-8601 expiry of the access token */
+  expiresAt: string;
+  refreshToken: string;
+};
+
+export type LoginResult =
+  | { ok: true; accountId: string; email: string; tokens: TokenPair }
+  | { ok: false; code: LoginErrorCode; message: string };
+
+export type LoginErrorCode =
+  | "VALIDATION_ERROR"
+  | "INVALID_CREDENTIALS"
+  | "RATE_LIMITED"
+  | "INTERNAL_ERROR";


### PR DESCRIPTION
Closes #323, closes #324, closes #325, closes #326

## What

- **AUTH-005** — Registration lifecycle tests: happy path, validation, duplicate email, and per-IP rate-limit. 20 tests, 0 failures, using `node:test` (no new deps).
- **AUTH-006** — Login types: `LoginInput`, `LoginResult`, `TokenPair`, `LoginErrorCode` added to `@qyou/types`.
- **AUTH-007** — Login service + `POST /api/v1/auth/login`: HS256 JWT issuance (15 min access / 7 day refresh UUID), wired into Express.
- **AUTH-008** — Hardening: `timingSafeEqual` password compare, per-IP rate-limit (5/60 s), generic `INVALID_CREDENTIALS` response (no email-existence leak).

## Structure

Shared account state extracted to `store.ts` so registration and login share one in-memory Map without circular imports.

## Verify

```
npm test --workspace @qyou/api   # 20 pass
npm run typecheck                # clean
```