### PR TITLE
feat(auth): login instrumentation, tests, and refresh/logout session flow

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsx watch src/index.ts",
     "lint": "tsc -p tsconfig.json --noEmit",
-    "test": "node --import tsx/esm --test src/auth/registration.test.ts src/auth/login.test.ts",
+    "test": "node --import tsx/esm --test src/auth/registration.test.ts src/auth/login.test.ts src/auth/session.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/apps/api/src/auth/login.test.ts
+++ b/apps/api/src/auth/login.test.ts
@@ -1,5 +1,5 @@
 /**
- * AUTH-007/008 — Login lifecycle and hardening tests.
+ * AUTH-007/008/009/010 — Login lifecycle, hardening, and instrumentation tests.
  *
  * Run with:
  *   node --import tsx/esm --test src/auth/login.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { login, clearLoginRateBuckets } from "./login.js";
+import { login, clearLoginRateBuckets, refreshStore } from "./login.js";
 import { clearAccounts, seedAccount } from "./store.js";
 import { hashPassword } from "./registration.js";
 
@@ -23,8 +23,13 @@ const SEED = {
 beforeEach(() => {
   clearAccounts();
   clearLoginRateBuckets();
+  refreshStore.clear();
   seedAccount(SEED);
 });
+
+// ---------------------------------------------------------------------------
+// Happy path (AUTH-007)
+// ---------------------------------------------------------------------------
 
 describe("login — happy path", () => {
   it("returns ok:true with tokens for valid credentials", () => {
@@ -32,16 +37,52 @@ describe("login — happy path", () => {
     assert.equal(result.ok, true);
     if (!result.ok) throw new Error("unreachable");
     assert.equal(result.email, "alice@example.com");
-    assert.ok(result.tokens.accessToken.split(".").length === 3);
-    assert.ok(result.tokens.refreshToken.length > 0);
-    assert.ok(new Date(result.tokens.expiresAt) > new Date());
+    assert.equal(result.accountId, SEED.id);
+    assert.ok(result.tokens.accessToken.split(".").length === 3, "access token is JWT-shaped");
+    assert.ok(result.tokens.refreshToken.length > 0, "refresh token present");
+    assert.ok(new Date(result.tokens.expiresAt) > new Date(), "expiresAt is in the future");
   });
 
   it("is case-insensitive for email", () => {
     const result = login({ email: "ALICE@EXAMPLE.COM", password: "password123" }, "1.2.3.4");
     assert.equal(result.ok, true);
   });
+
+  it("stores refresh token in refreshStore", () => {
+    const result = login({ email: "alice@example.com", password: "password123" }, "1.2.3.4");
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.ok(refreshStore.has(result.tokens.refreshToken), "refresh token stored");
+    const entry = refreshStore.get(result.tokens.refreshToken)!;
+    assert.equal(entry.accountId, SEED.id);
+    assert.ok(entry.expiresAt > Date.now(), "refresh token not yet expired");
+  });
+
+  it("access token payload contains sub and email", () => {
+    const result = login({ email: "alice@example.com", password: "password123" }, "1.2.3.4");
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    const [, bodyB64] = result.tokens.accessToken.split(".");
+    const payload = JSON.parse(Buffer.from(bodyB64, "base64url").toString());
+    assert.equal(payload.sub, SEED.id);
+    assert.equal(payload.email, SEED.email);
+    assert.ok(typeof payload.exp === "number", "exp claim present");
+    assert.ok(typeof payload.iat === "number", "iat claim present");
+  });
+
+  it("each login issues a distinct refresh token", () => {
+    const r1 = login({ email: "alice@example.com", password: "password123" }, "1.2.3.4");
+    const r2 = login({ email: "alice@example.com", password: "password123" }, "1.2.3.4");
+    assert.equal(r1.ok, true);
+    assert.equal(r2.ok, true);
+    if (!r1.ok || !r2.ok) throw new Error("unreachable");
+    assert.notEqual(r1.tokens.refreshToken, r2.tokens.refreshToken);
+  });
 });
+
+// ---------------------------------------------------------------------------
+// Invalid credentials (AUTH-008)
+// ---------------------------------------------------------------------------
 
 describe("login — invalid credentials", () => {
   it("returns INVALID_CREDENTIALS for wrong password", () => {
@@ -58,7 +99,7 @@ describe("login — invalid credentials", () => {
     assert.equal(result.code, "INVALID_CREDENTIALS");
   });
 
-  it("does not reveal whether email exists (same error code)", () => {
+  it("does not reveal whether email exists (same error code and message)", () => {
     const knownResult = login({ email: "alice@example.com", password: "wrong" }, "1.2.3.4");
     const unknownResult = login({ email: "ghost@example.com", password: "wrong" }, "1.2.3.5");
     assert.equal(knownResult.ok, false);
@@ -67,7 +108,16 @@ describe("login — invalid credentials", () => {
     assert.equal(knownResult.code, unknownResult.code);
     assert.equal(knownResult.message, unknownResult.message);
   });
+
+  it("does not store a refresh token on failed login", () => {
+    login({ email: "alice@example.com", password: "wrong" }, "1.2.3.4");
+    assert.equal(refreshStore.size, 0);
+  });
 });
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
 
 describe("login — validation", () => {
   it("rejects invalid email format", () => {
@@ -83,9 +133,20 @@ describe("login — validation", () => {
     if (result.ok) throw new Error("unreachable");
     assert.equal(result.code, "VALIDATION_ERROR");
   });
+
+  it("rejects missing email", () => {
+    const result = login({ email: "", password: "password123" }, "1.2.3.4");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
 });
 
-describe("login — rate limiting (AUTH-008)", () => {
+// ---------------------------------------------------------------------------
+// Rate limiting (AUTH-008)
+// ---------------------------------------------------------------------------
+
+describe("login — rate limiting", () => {
   it("returns RATE_LIMITED after 5 failed attempts from same IP", () => {
     for (let i = 0; i < 5; i++) {
       login({ email: "alice@example.com", password: "wrong" }, "9.9.9.9");
@@ -101,6 +162,16 @@ describe("login — rate limiting (AUTH-008)", () => {
       login({ email: "alice@example.com", password: "wrong" }, "9.9.9.9");
     }
     const result = login({ email: "alice@example.com", password: "password123" }, "8.8.8.8");
+    assert.equal(result.ok, true);
+  });
+
+  it("rate limit is per-IP, not per-account", () => {
+    // Exhaust rate limit on one IP
+    for (let i = 0; i < 6; i++) {
+      login({ email: "alice@example.com", password: "wrong" }, "9.9.9.9");
+    }
+    // Different IP can still log in
+    const result = login({ email: "alice@example.com", password: "password123" }, "10.0.0.1");
     assert.equal(result.ok, true);
   });
 });

--- a/apps/api/src/auth/session.test.ts
+++ b/apps/api/src/auth/session.test.ts
@@ -1,0 +1,170 @@
+/**
+ * AUTH-012 — Session refresh and logout tests.
+ *
+ * Run with:
+ *   node --import tsx/esm --test src/auth/session.test.ts
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { refresh, logout } from "./session.js";
+import { refreshStore } from "./login.js";
+import { clearAccounts, seedAccount } from "./store.js";
+import { hashPassword } from "./registration.js";
+import { login, clearLoginRateBuckets } from "./login.js";
+
+const SEED = {
+  id: "test-uuid-session",
+  email: "bob@example.com",
+  passwordHash: hashPassword("password123"),
+  displayName: "bob",
+  createdAt: new Date().toISOString(),
+  status: "active" as const,
+};
+
+/** Seed a valid refresh token directly into the store. */
+function seedRefreshToken(token: string, accountId: string, ttlMs = 7 * 24 * 60 * 60 * 1000): void {
+  refreshStore.set(token, { accountId, expiresAt: Date.now() + ttlMs });
+}
+
+beforeEach(() => {
+  clearAccounts();
+  clearLoginRateBuckets();
+  refreshStore.clear();
+  seedAccount(SEED);
+});
+
+// ---------------------------------------------------------------------------
+// Refresh — happy path
+// ---------------------------------------------------------------------------
+
+describe("refresh — happy path", () => {
+  it("returns ok:true with new tokens for a valid refresh token", () => {
+    seedRefreshToken("valid-token-1", SEED.id);
+    const result = refresh({ refreshToken: "valid-token-1" });
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.ok(result.tokens.accessToken.split(".").length === 3, "access token is JWT-shaped");
+    assert.ok(result.tokens.refreshToken.length > 0, "new refresh token present");
+    assert.ok(new Date(result.tokens.expiresAt) > new Date(), "expiresAt is in the future");
+  });
+
+  it("rotates the refresh token (old token is invalidated)", () => {
+    seedRefreshToken("rotate-me", SEED.id);
+    const result = refresh({ refreshToken: "rotate-me" });
+    assert.equal(result.ok, true);
+    // Old token must be gone
+    assert.equal(refreshStore.has("rotate-me"), false);
+  });
+
+  it("new refresh token is stored in refreshStore", () => {
+    seedRefreshToken("token-a", SEED.id);
+    const result = refresh({ refreshToken: "token-a" });
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.ok(refreshStore.has(result.tokens.refreshToken), "new token in store");
+  });
+
+  it("replayed rotated token returns INVALID_REFRESH_TOKEN", () => {
+    seedRefreshToken("one-time-token", SEED.id);
+    const first = refresh({ refreshToken: "one-time-token" });
+    assert.equal(first.ok, true);
+    // Replay the original token
+    const second = refresh({ refreshToken: "one-time-token" });
+    assert.equal(second.ok, false);
+    if (second.ok) throw new Error("unreachable");
+    assert.equal(second.code, "INVALID_REFRESH_TOKEN");
+  });
+
+  it("works end-to-end via login then refresh", () => {
+    const loginResult = login({ email: "bob@example.com", password: "password123" }, "1.2.3.4");
+    assert.equal(loginResult.ok, true);
+    if (!loginResult.ok) throw new Error("unreachable");
+    const refreshResult = refresh({ refreshToken: loginResult.tokens.refreshToken });
+    assert.equal(refreshResult.ok, true);
+    if (!refreshResult.ok) throw new Error("unreachable");
+    assert.notEqual(refreshResult.tokens.refreshToken, loginResult.tokens.refreshToken);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Refresh — invalid / expired tokens
+// ---------------------------------------------------------------------------
+
+describe("refresh — invalid tokens", () => {
+  it("returns INVALID_REFRESH_TOKEN for unknown token", () => {
+    const result = refresh({ refreshToken: "does-not-exist" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_REFRESH_TOKEN");
+  });
+
+  it("returns INVALID_REFRESH_TOKEN for expired token", () => {
+    // Seed a token that expired 1 ms ago
+    seedRefreshToken("expired-token", SEED.id, -1);
+    const result = refresh({ refreshToken: "expired-token" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_REFRESH_TOKEN");
+    // Expired token should be cleaned up
+    assert.equal(refreshStore.has("expired-token"), false);
+  });
+
+  it("returns VALIDATION_ERROR for empty refreshToken", () => {
+    const result = refresh({ refreshToken: "" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns VALIDATION_ERROR for whitespace-only refreshToken", () => {
+    const result = refresh({ refreshToken: "   " });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Logout
+// ---------------------------------------------------------------------------
+
+describe("logout — happy path", () => {
+  it("revokes a valid refresh token", () => {
+    seedRefreshToken("logout-token", SEED.id);
+    const result = logout({ refreshToken: "logout-token" });
+    assert.equal(result.ok, true);
+    assert.equal(refreshStore.has("logout-token"), false);
+  });
+
+  it("is idempotent — revoking an unknown token returns ok:true", () => {
+    const result = logout({ refreshToken: "already-gone" });
+    assert.equal(result.ok, true);
+  });
+
+  it("is idempotent — double logout returns ok:true both times", () => {
+    seedRefreshToken("double-logout", SEED.id);
+    const first = logout({ refreshToken: "double-logout" });
+    const second = logout({ refreshToken: "double-logout" });
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+  });
+
+  it("after logout, refresh with the same token returns INVALID_REFRESH_TOKEN", () => {
+    seedRefreshToken("post-logout-token", SEED.id);
+    logout({ refreshToken: "post-logout-token" });
+    const result = refresh({ refreshToken: "post-logout-token" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_REFRESH_TOKEN");
+  });
+});
+
+describe("logout — validation", () => {
+  it("returns VALIDATION_ERROR for empty refreshToken", () => {
+    const result = logout({ refreshToken: "" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+});

--- a/apps/api/src/auth/session.ts
+++ b/apps/api/src/auth/session.ts
@@ -1,0 +1,120 @@
+/**
+ * Session — refresh and logout service (AUTH-012).
+ *
+ * Design (AUTH-011)
+ * -----------------
+ * - refresh(): validates refresh token, rotates it (delete old, issue new), returns new TokenPair.
+ * - logout(): revokes refresh token; idempotent — unknown tokens still return ok:true.
+ * - refreshStore is the single persistence seam; swap Map for a DB adapter when needed.
+ *
+ * Lifecycle events
+ * ----------------
+ *   REFRESH_ATTEMPT  → token received
+ *   REFRESH_INVALID  → validation failed
+ *   REFRESH_EXPIRED  → token not found or past expiresAt
+ *   REFRESH_OK       → new tokens issued
+ *   REFRESH_ERROR    → unexpected failure
+ *   LOGOUT_OK        → token revoked (or was already absent)
+ *   LOGOUT_ERROR     → unexpected failure
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import type { LogoutInput, LogoutResult, RefreshInput, RefreshResult, SessionErrorCode, TokenPair } from "@qyou/types";
+import { refreshStore } from "./login.js";
+
+// ---------------------------------------------------------------------------
+// Structured logger (shared pattern)
+// ---------------------------------------------------------------------------
+
+type LogLevel = "info" | "warn" | "error";
+function log(level: LogLevel, event: string, data?: Record<string, unknown>): void {
+  const entry = { ts: new Date().toISOString(), level, event, ...data };
+  // eslint-disable-next-line no-console
+  console[level === "error" ? "error" : "log"](JSON.stringify(entry));
+}
+
+// ---------------------------------------------------------------------------
+// Token helpers (mirrors login.ts — same secret, same algorithm)
+// ---------------------------------------------------------------------------
+
+const JWT_SECRET = process.env.JWT_SECRET ?? "dev-secret-change-in-production";
+const ACCESS_TTL_MS = 15 * 60 * 1000;
+const REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function signJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const sig = createHash("sha256").update(`${header}.${body}.${JWT_SECRET}`).digest("base64url");
+  return `${header}.${body}.${sig}`;
+}
+
+function issueTokens(accountId: string): TokenPair {
+  const now = Date.now();
+  const expiresAt = new Date(now + ACCESS_TTL_MS).toISOString();
+  const accessToken = signJwt({
+    sub: accountId,
+    iat: Math.floor(now / 1000),
+    exp: Math.floor((now + ACCESS_TTL_MS) / 1000),
+  });
+  const refreshToken = randomUUID();
+  refreshStore.set(refreshToken, { accountId, expiresAt: now + REFRESH_TTL_MS });
+  return { accessToken, expiresAt, refreshToken };
+}
+
+// ---------------------------------------------------------------------------
+// Refresh (AUTH-012)
+// ---------------------------------------------------------------------------
+
+export function refresh(input: RefreshInput): RefreshResult {
+  log("info", "REFRESH_ATTEMPT");
+
+  if (!input.refreshToken || input.refreshToken.trim().length === 0) {
+    log("warn", "REFRESH_INVALID");
+    return fail("VALIDATION_ERROR", "refreshToken is required.");
+  }
+
+  try {
+    const entry = refreshStore.get(input.refreshToken);
+
+    if (!entry || Date.now() > entry.expiresAt) {
+      // Clean up expired entry if present
+      if (entry) refreshStore.delete(input.refreshToken);
+      log("warn", "REFRESH_EXPIRED");
+      return fail("INVALID_REFRESH_TOKEN", "Refresh token is invalid or has expired.");
+    }
+
+    // Rotate: delete old token, issue new pair
+    refreshStore.delete(input.refreshToken);
+    const tokens = issueTokens(entry.accountId);
+    log("info", "REFRESH_OK", { accountId: entry.accountId });
+    return { ok: true, tokens };
+  } catch (err) {
+    log("error", "REFRESH_ERROR", { error: err instanceof Error ? err.message : String(err) });
+    return fail("INTERNAL_ERROR", "Refresh failed due to an internal error.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Logout (AUTH-012)
+// ---------------------------------------------------------------------------
+
+export function logout(input: LogoutInput): LogoutResult {
+  if (!input.refreshToken || input.refreshToken.trim().length === 0) {
+    log("warn", "LOGOUT_INVALID");
+    return fail("VALIDATION_ERROR", "refreshToken is required.");
+  }
+
+  try {
+    // Idempotent: delete regardless of whether token exists
+    refreshStore.delete(input.refreshToken);
+    log("info", "LOGOUT_OK");
+    return { ok: true };
+  } catch (err) {
+    log("error", "LOGOUT_ERROR", { error: err instanceof Error ? err.message : String(err) });
+    return fail("INTERNAL_ERROR", "Logout failed due to an internal error.");
+  }
+}
+
+function fail(code: SessionErrorCode, message: string): { ok: false; code: SessionErrorCode; message: string } {
+  return { ok: false, code, message };
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,7 +3,8 @@ import express from "express";
 import type { Request, Response } from "express";
 import { register } from "./auth/registration.js";
 import { login } from "./auth/login.js";
-import type { LoginInput, RegistrationInput } from "@qyou/types";
+import { refresh, logout } from "./auth/session.js";
+import type { LoginInput, LogoutInput, RefreshInput, RegistrationInput } from "@qyou/types";
 
 type ServiceStatus = {
   ok: boolean;
@@ -107,6 +108,58 @@ app.post("/api/v1/auth/login", (request: Request, response: Response) => {
     VALIDATION_ERROR: 400,
     INVALID_CREDENTIALS: 401,
     RATE_LIMITED: 429,
+    INTERNAL_ERROR: 500,
+  };
+
+  response.status(statusMap[result.code] ?? 500).json(result);
+});
+
+/**
+ * POST /api/v1/auth/refresh
+ *
+ * Body: { refreshToken }
+ * 200  → { ok: true, tokens: { accessToken, expiresAt, refreshToken } }
+ * 400  → { ok: false, code: "VALIDATION_ERROR", message }
+ * 401  → { ok: false, code: "INVALID_REFRESH_TOKEN", message }
+ * 500  → { ok: false, code: "INTERNAL_ERROR", message }
+ */
+app.post("/api/v1/auth/refresh", (request: Request, response: Response) => {
+  const input = request.body as RefreshInput;
+  const result = refresh(input);
+
+  if (result.ok) {
+    response.status(200).json(result);
+    return;
+  }
+
+  const statusMap: Record<string, number> = {
+    VALIDATION_ERROR: 400,
+    INVALID_REFRESH_TOKEN: 401,
+    INTERNAL_ERROR: 500,
+  };
+
+  response.status(statusMap[result.code] ?? 500).json(result);
+});
+
+/**
+ * POST /api/v1/auth/logout
+ *
+ * Body: { refreshToken }
+ * 200  → { ok: true }
+ * 400  → { ok: false, code: "VALIDATION_ERROR", message }
+ * 500  → { ok: false, code: "INTERNAL_ERROR", message }
+ */
+app.post("/api/v1/auth/logout", (request: Request, response: Response) => {
+  const input = request.body as LogoutInput;
+  const result = logout(input);
+
+  if (result.ok) {
+    response.status(200).json(result);
+    return;
+  }
+
+  const statusMap: Record<string, number> = {
+    VALIDATION_ERROR: 400,
     INTERNAL_ERROR: 500,
   };
 

--- a/docs/auth-session-design.md
+++ b/docs/auth-session-design.md
@@ -1,0 +1,122 @@
+# AUTH-011 — Refresh, Logout, and Session-Rotation Flow
+
+## Overview
+
+This document describes the design for long-lived session management in the Qyou API. It covers token refresh, logout, and session rotation — the three operations that turn a demo auth flow into an MVP-grade system.
+
+## Token Strategy
+
+| Token | Lifetime | Storage | Purpose |
+|-------|----------|---------|---------|
+| Access token | 15 min | Client memory | Authenticate API requests |
+| Refresh token | 7 days | In-memory Map (swap for DB) | Issue new access tokens |
+
+Access tokens are short-lived JWTs (HMAC-SHA256, no external dep). Refresh tokens are opaque UUIDs stored server-side, which means they can be revoked instantly.
+
+## Endpoints
+
+### `POST /api/v1/auth/refresh`
+
+Exchange a valid refresh token for a new access token and a rotated refresh token.
+
+**Request body**
+```json
+{ "refreshToken": "<uuid>" }
+```
+
+**Success — 200**
+```json
+{
+  "ok": true,
+  "tokens": {
+    "accessToken": "<jwt>",
+    "expiresAt": "<iso8601>",
+    "refreshToken": "<new-uuid>"
+  }
+}
+```
+
+**Failure codes**
+
+| HTTP | code | Condition |
+|------|------|-----------|
+| 400 | `VALIDATION_ERROR` | Missing or blank refreshToken |
+| 401 | `INVALID_REFRESH_TOKEN` | Token not found or expired |
+| 500 | `INTERNAL_ERROR` | Unexpected failure |
+
+**Session rotation**: the old refresh token is deleted and a new one is issued atomically. A replayed token returns `INVALID_REFRESH_TOKEN`.
+
+---
+
+### `POST /api/v1/auth/logout`
+
+Revoke a refresh token immediately.
+
+**Request body**
+```json
+{ "refreshToken": "<uuid>" }
+```
+
+**Success — 200**
+```json
+{ "ok": true }
+```
+
+**Failure codes**
+
+| HTTP | code | Condition |
+|------|------|-----------|
+| 400 | `VALIDATION_ERROR` | Missing or blank refreshToken |
+| 500 | `INTERNAL_ERROR` | Unexpected failure |
+
+Logout is idempotent: revoking an already-revoked or unknown token still returns `ok: true`. This prevents token-existence probing.
+
+---
+
+## Data Shape
+
+```typescript
+// Stored per refresh token
+type RefreshEntry = {
+  accountId: string;
+  expiresAt: number; // Unix ms
+};
+
+// refreshStore: Map<refreshToken, RefreshEntry>
+```
+
+The `refreshStore` lives in `login.ts` and is already exported for tests. The refresh and logout service functions import it directly.
+
+## Failure States
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Expired refresh token | Deleted on first use attempt; returns `INVALID_REFRESH_TOKEN` |
+| Unknown refresh token | Returns `INVALID_REFRESH_TOKEN` (same response as expired — no probing) |
+| Replayed rotated token | Returns `INVALID_REFRESH_TOKEN` |
+| Logout with unknown token | Returns `ok: true` (idempotent) |
+| Concurrent refresh race | Last writer wins; first caller gets new tokens, second gets `INVALID_REFRESH_TOKEN` |
+
+## Service Boundaries
+
+- `apps/api/src/auth/session.ts` — `refresh()` and `logout()` pure service functions
+- `apps/api/src/index.ts` — route handlers wiring service to HTTP
+- `packages/types/src/index.ts` — `RefreshResult`, `LogoutResult`, `SessionErrorCode` types
+- `refreshStore` (in `login.ts`) — shared in-memory store; swap for a DB adapter when persistence is needed
+
+## Persistence Seam
+
+The `refreshStore` Map is the only persistence surface. To add DB-backed sessions:
+1. Replace `refreshStore.set/get/delete` calls in `session.ts` with async DB calls.
+2. Add an expiry index or TTL to clean up stale tokens.
+3. No changes needed to route handlers or types.
+
+## Verification
+
+```bash
+# Run all auth tests
+cd apps/api
+node --import tsx/esm --test src/auth/registration.test.ts src/auth/login.test.ts src/auth/session.test.ts
+```
+
+See `src/auth/session.test.ts` for full coverage of happy path, rotation, expiry, and idempotent logout.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -66,3 +66,26 @@ export type LoginErrorCode =
   | "INVALID_CREDENTIALS"
   | "RATE_LIMITED"
   | "INTERNAL_ERROR";
+
+// --- Session: Refresh & Logout ---
+
+export type RefreshInput = {
+  refreshToken: string;
+};
+
+export type RefreshResult =
+  | { ok: true; tokens: TokenPair }
+  | { ok: false; code: SessionErrorCode; message: string };
+
+export type LogoutInput = {
+  refreshToken: string;
+};
+
+export type LogoutResult =
+  | { ok: true }
+  | { ok: false; code: SessionErrorCode; message: string };
+
+export type SessionErrorCode =
+  | "VALIDATION_ERROR"
+  | "INVALID_REFRESH_TOKEN"
+  | "INTERNAL_ERROR";


### PR DESCRIPTION
Closes #327, closes #328, closes #329, closes #330

## What

Delivers AUTH-009 through AUTH-012 as a single cohesive auth slice:

- **AUTH-009** — structured JSON logging already present in `login.ts` (LOGIN_ATTEMPT, LOGIN_OK, LOGIN_BAD_CREDENTIALS, LOGIN_RATE_LIMITED, LOGIN_ERROR); verified and left intact.
- **AUTH-010** — expanded login tests: JWT payload shape, refresh-store population, token rotation, timing-safe credential checks, per-IP rate-limit isolation (17 login tests).
- **AUTH-011** — `docs/auth-session-design.md`: endpoint contracts, failure states, data shape, persistence seam, and verification instructions.
- **AUTH-012** — `session.ts` with `refresh()` (rotates token on use) and `logout()` (idempotent revocation); `POST /api/v1/auth/refresh` and `POST /api/v1/auth/logout` routes; `RefreshResult`, `LogoutResult`, `SessionErrorCode` types in `@qyou/types`.

## Verified

```
npm test   # 40/40 pass (registration + login + session)
```