### PR TITLE
auth: harden, instrument, verify session flow; design password reset

### DIFF
--- a/apps/api/src/auth/password-reset.test.ts
+++ b/apps/api/src/auth/password-reset.test.ts
@@ -1,0 +1,123 @@
+/**
+ * AUTH-016 — Password reset smoke tests.
+ *
+ * Run with:
+ *   node --import tsx/esm --test src/auth/password-reset.test.ts
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { requestReset, confirmReset, resetStore, clearResetRateBuckets } from "./password-reset.js";
+import { refreshStore } from "./login.js";
+import { clearAccounts, seedAccount } from "./store.js";
+import { hashPassword } from "./registration.js";
+import { login, clearLoginRateBuckets } from "./login.js";
+
+const SEED = {
+  id: "test-uuid-reset",
+  email: "alice@example.com",
+  passwordHash: hashPassword("oldpassword1"),
+  displayName: "alice",
+  createdAt: new Date().toISOString(),
+  status: "active" as const,
+};
+
+beforeEach(() => {
+  clearAccounts();
+  clearLoginRateBuckets();
+  clearResetRateBuckets();
+  refreshStore.clear();
+  resetStore.clear();
+  // Spread to prevent mutation bleed between tests (confirmReset mutates passwordHash)
+  seedAccount({ ...SEED });
+});
+
+describe("requestReset", () => {
+  it("returns ok:true for a known email", () => {
+    const result = requestReset({ email: "alice@example.com" }, "1.2.3.4");
+    assert.equal(result.ok, true);
+  });
+
+  it("returns ok:true for an unknown email (no enumeration)", () => {
+    const result = requestReset({ email: "nobody@example.com" }, "1.2.3.4");
+    assert.equal(result.ok, true);
+  });
+
+  it("returns VALIDATION_ERROR for invalid email", () => {
+    const result = requestReset({ email: "not-an-email" }, "1.2.3.4");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("stores a reset token for a known account", () => {
+    requestReset({ email: "alice@example.com" }, "1.2.3.4");
+    assert.equal(resetStore.size, 1);
+  });
+});
+
+describe("confirmReset", () => {
+  it("returns VALIDATION_ERROR for missing token", () => {
+    const result = confirmReset({ token: "", newPassword: "newpassword1" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns VALIDATION_ERROR for short newPassword", () => {
+    const result = confirmReset({ token: "a".repeat(36), newPassword: "short" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns INVALID_RESET_TOKEN for unknown token", () => {
+    const result = confirmReset({ token: "b".repeat(36), newPassword: "newpassword1" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_RESET_TOKEN");
+  });
+
+  it("returns INVALID_RESET_TOKEN for expired token", () => {
+    resetStore.set("c".repeat(36), { accountId: SEED.id, expiresAt: Date.now() - 1 });
+    const result = confirmReset({ token: "c".repeat(36), newPassword: "newpassword1" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_RESET_TOKEN");
+  });
+
+  it("succeeds with a valid token and updates the password", () => {
+    requestReset({ email: "alice@example.com" }, "1.2.3.4");
+    const token = [...resetStore.keys()][0]!;
+    const result = confirmReset({ token, newPassword: "newpassword1" });
+    assert.equal(result.ok, true);
+    // Token consumed
+    assert.equal(resetStore.has(token), false);
+    // Can now login with new password
+    const loginResult = login({ email: "alice@example.com", password: "newpassword1" }, "1.2.3.4");
+    assert.equal(loginResult.ok, true);
+  });
+
+  it("revokes all refresh tokens for the account on confirm", () => {
+    const loginResult = login({ email: "alice@example.com", password: "oldpassword1" }, "1.2.3.4");
+    assert.equal(loginResult.ok, true);
+    if (!loginResult.ok) throw new Error("unreachable");
+    assert.equal(refreshStore.size, 1);
+
+    requestReset({ email: "alice@example.com" }, "1.2.3.4");
+    const token = [...resetStore.keys()][0]!;
+    confirmReset({ token, newPassword: "newpassword1" });
+
+    assert.equal(refreshStore.size, 0, "all refresh tokens revoked");
+  });
+
+  it("is single-use — replaying the token returns INVALID_RESET_TOKEN", () => {
+    requestReset({ email: "alice@example.com" }, "1.2.3.4");
+    const token = [...resetStore.keys()][0]!;
+    confirmReset({ token, newPassword: "newpassword1" });
+    const second = confirmReset({ token, newPassword: "anotherpassword" });
+    assert.equal(second.ok, false);
+    if (second.ok) throw new Error("unreachable");
+    assert.equal(second.code, "INVALID_RESET_TOKEN");
+  });
+});

--- a/apps/api/src/auth/password-reset.ts
+++ b/apps/api/src/auth/password-reset.ts
@@ -1,0 +1,195 @@
+/**
+ * Password Reset — service stub (AUTH-016).
+ *
+ * Design: docs/auth-password-reset.md
+ *
+ * Two operations:
+ *   requestReset(email)         → always ok:true (no email enumeration)
+ *   confirmReset(token, newPw)  → validates token, updates password, revokes sessions
+ *
+ * Wire the route handlers in index.ts when ready to expose via HTTP.
+ * Swap resetStore for a DB adapter when persistence is needed.
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  PasswordResetConfirmInput,
+  PasswordResetConfirmResult,
+  PasswordResetRequestInput,
+  PasswordResetRequestResult,
+} from "@qyou/types";
+import { hashPassword } from "./registration.js";
+import { accountsByEmail } from "./store.js";
+import { refreshStore } from "./login.js";
+
+// ---------------------------------------------------------------------------
+// Structured logger
+// ---------------------------------------------------------------------------
+
+type LogLevel = "info" | "warn" | "error";
+function log(level: LogLevel, event: string, data?: Record<string, unknown>): void {
+  const entry = { ts: new Date().toISOString(), level, event, ...data };
+  // eslint-disable-next-line no-console
+  console[level === "error" ? "error" : "log"](JSON.stringify(entry));
+}
+
+// ---------------------------------------------------------------------------
+// Reset token store
+// ---------------------------------------------------------------------------
+
+const RESET_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const RESET_STORE_MAX_SIZE = 1_000;
+
+type ResetEntry = { accountId: string; expiresAt: number };
+export const resetStore = new Map<string, ResetEntry>();
+
+function storeResetToken(accountId: string): string {
+  const token = randomUUID();
+  if (resetStore.size >= RESET_STORE_MAX_SIZE) {
+    const oldest = resetStore.keys().next().value;
+    if (oldest !== undefined) resetStore.delete(oldest);
+  }
+  resetStore.set(token, { accountId, expiresAt: Date.now() + RESET_TTL_MS });
+  return token;
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit (per-IP for request, per-token for confirm)
+// ---------------------------------------------------------------------------
+
+const RATE_WINDOW_MS = 60_000;
+const rateBuckets = new Map<string, { count: number; windowStart: number }>();
+
+function isRateLimited(key: string, max: number): boolean {
+  const now = Date.now();
+  const bucket = rateBuckets.get(key);
+  if (!bucket || now - bucket.windowStart > RATE_WINDOW_MS) {
+    rateBuckets.set(key, { count: 1, windowStart: now });
+    return false;
+  }
+  bucket.count += 1;
+  return bucket.count > max;
+}
+
+/** For tests: reset rate-limit state. */
+export function clearResetRateBuckets(): void {
+  rateBuckets.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PASSWORD_LEN = 8;
+
+// ---------------------------------------------------------------------------
+// requestReset (AUTH-016)
+// ---------------------------------------------------------------------------
+
+export function requestReset(input: PasswordResetRequestInput, ip: string): PasswordResetRequestResult {
+  const start = Date.now();
+  log("info", "RESET_REQUEST_ATTEMPT", { ip });
+
+  if (!input.email || !EMAIL_RE.test(input.email)) {
+    log("warn", "RESET_REQUEST_INVALID", { ip, latency_ms: Date.now() - start });
+    return { ok: false, code: "VALIDATION_ERROR", message: "A valid email address is required." };
+  }
+
+  if (isRateLimited(`reset-req:${ip}`, 5)) {
+    log("warn", "RESET_REQUEST_RATE_LIMITED", { ip, latency_ms: Date.now() - start });
+    // Still return ok:true to prevent enumeration via rate-limit probing
+    return { ok: true };
+  }
+
+  try {
+    const email = input.email.trim().toLowerCase();
+    const account = accountsByEmail.get(email);
+
+    if (account) {
+      const token = storeResetToken(account.id);
+      // TODO: deliver token via email transport
+      log("info", "RESET_REQUESTED", {
+        accountId: account.id,
+        tokenPrefix: token.slice(0, 8),
+        latency_ms: Date.now() - start,
+      });
+    } else {
+      // Unknown email — log quietly, return same response
+      log("info", "RESET_REQUEST_UNKNOWN_EMAIL", { latency_ms: Date.now() - start });
+    }
+
+    return { ok: true };
+  } catch (err) {
+    log("error", "RESET_REQUEST_ERROR", {
+      ip,
+      error: err instanceof Error ? err.message : String(err),
+      latency_ms: Date.now() - start,
+    });
+    return { ok: false, code: "INTERNAL_ERROR", message: "Request failed due to an internal error." };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// confirmReset (AUTH-016)
+// ---------------------------------------------------------------------------
+
+export function confirmReset(input: PasswordResetConfirmInput): PasswordResetConfirmResult {
+  const start = Date.now();
+  const tokenPrefix = input.token ? input.token.slice(0, 8) : "";
+  log("info", "RESET_CONFIRM_ATTEMPT", { tokenPrefix });
+
+  if (!input.token || input.token.trim().length === 0) {
+    return { ok: false, code: "VALIDATION_ERROR", message: "token is required." };
+  }
+  if (!input.newPassword || input.newPassword.length < MIN_PASSWORD_LEN) {
+    return {
+      ok: false,
+      code: "VALIDATION_ERROR",
+      message: `newPassword must be at least ${MIN_PASSWORD_LEN} characters.`,
+    };
+  }
+
+  if (isRateLimited(`reset-confirm:${input.token}`, 3)) {
+    log("warn", "RESET_CONFIRM_RATE_LIMITED", { tokenPrefix, latency_ms: Date.now() - start });
+    return { ok: false, code: "INVALID_RESET_TOKEN", message: "Reset token is invalid or has expired." };
+  }
+
+  try {
+    const entry = resetStore.get(input.token);
+
+    if (!entry || Date.now() > entry.expiresAt) {
+      if (entry) resetStore.delete(input.token);
+      log("warn", "RESET_CONFIRM_EXPIRED", { tokenPrefix, latency_ms: Date.now() - start });
+      return { ok: false, code: "INVALID_RESET_TOKEN", message: "Reset token is invalid or has expired." };
+    }
+
+    // Find account and update password
+    const account = [...accountsByEmail.values()].find((a) => a.id === entry.accountId);
+    if (!account) {
+      resetStore.delete(input.token);
+      log("warn", "RESET_CONFIRM_NO_ACCOUNT", { accountId: entry.accountId, latency_ms: Date.now() - start });
+      return { ok: false, code: "INVALID_RESET_TOKEN", message: "Reset token is invalid or has expired." };
+    }
+
+    account.passwordHash = hashPassword(input.newPassword);
+
+    // Single-use: delete reset token
+    resetStore.delete(input.token);
+
+    // Revoke all active refresh tokens for this account (force re-login)
+    for (const [rt, rtEntry] of refreshStore) {
+      if (rtEntry.accountId === entry.accountId) refreshStore.delete(rt);
+    }
+
+    log("info", "RESET_CONFIRMED", { accountId: entry.accountId, latency_ms: Date.now() - start });
+    return { ok: true };
+  } catch (err) {
+    log("error", "RESET_CONFIRM_ERROR", {
+      tokenPrefix,
+      error: err instanceof Error ? err.message : String(err),
+      latency_ms: Date.now() - start,
+    });
+    return { ok: false, code: "INTERNAL_ERROR", message: "Confirm failed due to an internal error." };
+  }
+}

--- a/apps/api/src/auth/session.test.ts
+++ b/apps/api/src/auth/session.test.ts
@@ -1,5 +1,5 @@
 /**
- * AUTH-012 — Session refresh and logout tests.
+ * AUTH-012 / AUTH-015 — Session refresh and logout tests.
  *
  * Run with:
  *   node --import tsx/esm --test src/auth/session.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { refresh, logout } from "./session.js";
+import { refresh, logout, refreshInFlight, STORE_MAX_SIZE } from "./session.js";
 import { refreshStore } from "./login.js";
 import { clearAccounts, seedAccount } from "./store.js";
 import { hashPassword } from "./registration.js";
@@ -31,6 +31,7 @@ beforeEach(() => {
   clearAccounts();
   clearLoginRateBuckets();
   refreshStore.clear();
+  refreshInFlight.clear();
   seedAccount(SEED);
 });
 
@@ -40,8 +41,8 @@ beforeEach(() => {
 
 describe("refresh — happy path", () => {
   it("returns ok:true with new tokens for a valid refresh token", () => {
-    seedRefreshToken("valid-token-1", SEED.id);
-    const result = refresh({ refreshToken: "valid-token-1" });
+    seedRefreshToken("a".repeat(36), SEED.id);
+    const result = refresh({ refreshToken: "a".repeat(36) });
     assert.equal(result.ok, true);
     if (!result.ok) throw new Error("unreachable");
     assert.ok(result.tokens.accessToken.split(".").length === 3, "access token is JWT-shaped");
@@ -50,27 +51,28 @@ describe("refresh — happy path", () => {
   });
 
   it("rotates the refresh token (old token is invalidated)", () => {
-    seedRefreshToken("rotate-me", SEED.id);
-    const result = refresh({ refreshToken: "rotate-me" });
+    const token = "b".repeat(36);
+    seedRefreshToken(token, SEED.id);
+    const result = refresh({ refreshToken: token });
     assert.equal(result.ok, true);
-    // Old token must be gone
-    assert.equal(refreshStore.has("rotate-me"), false);
+    assert.equal(refreshStore.has(token), false);
   });
 
   it("new refresh token is stored in refreshStore", () => {
-    seedRefreshToken("token-a", SEED.id);
-    const result = refresh({ refreshToken: "token-a" });
+    const token = "c".repeat(36);
+    seedRefreshToken(token, SEED.id);
+    const result = refresh({ refreshToken: token });
     assert.equal(result.ok, true);
     if (!result.ok) throw new Error("unreachable");
     assert.ok(refreshStore.has(result.tokens.refreshToken), "new token in store");
   });
 
   it("replayed rotated token returns INVALID_REFRESH_TOKEN", () => {
-    seedRefreshToken("one-time-token", SEED.id);
-    const first = refresh({ refreshToken: "one-time-token" });
+    const token = "d".repeat(36);
+    seedRefreshToken(token, SEED.id);
+    const first = refresh({ refreshToken: token });
     assert.equal(first.ok, true);
-    // Replay the original token
-    const second = refresh({ refreshToken: "one-time-token" });
+    const second = refresh({ refreshToken: token });
     assert.equal(second.ok, false);
     if (second.ok) throw new Error("unreachable");
     assert.equal(second.code, "INVALID_REFRESH_TOKEN");
@@ -93,21 +95,20 @@ describe("refresh — happy path", () => {
 
 describe("refresh — invalid tokens", () => {
   it("returns INVALID_REFRESH_TOKEN for unknown token", () => {
-    const result = refresh({ refreshToken: "does-not-exist" });
+    const result = refresh({ refreshToken: "e".repeat(36) });
     assert.equal(result.ok, false);
     if (result.ok) throw new Error("unreachable");
     assert.equal(result.code, "INVALID_REFRESH_TOKEN");
   });
 
   it("returns INVALID_REFRESH_TOKEN for expired token", () => {
-    // Seed a token that expired 1 ms ago
-    seedRefreshToken("expired-token", SEED.id, -1);
-    const result = refresh({ refreshToken: "expired-token" });
+    const token = "f".repeat(36);
+    seedRefreshToken(token, SEED.id, -1);
+    const result = refresh({ refreshToken: token });
     assert.equal(result.ok, false);
     if (result.ok) throw new Error("unreachable");
     assert.equal(result.code, "INVALID_REFRESH_TOKEN");
-    // Expired token should be cleaned up
-    assert.equal(refreshStore.has("expired-token"), false);
+    assert.equal(refreshStore.has(token), false);
   });
 
   it("returns VALIDATION_ERROR for empty refreshToken", () => {
@@ -126,34 +127,129 @@ describe("refresh — invalid tokens", () => {
 });
 
 // ---------------------------------------------------------------------------
+// AUTH-013: Token-length guard
+// ---------------------------------------------------------------------------
+
+describe("refresh — token-length guard (AUTH-013)", () => {
+  it("rejects a token shorter than 36 chars with VALIDATION_ERROR", () => {
+    const result = refresh({ refreshToken: "short" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("rejects a token longer than 36 chars with VALIDATION_ERROR", () => {
+    const result = refresh({ refreshToken: "x".repeat(37) });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("accepts a token of exactly 36 chars (UUID length)", () => {
+    const token = "g".repeat(36);
+    seedRefreshToken(token, SEED.id);
+    const result = refresh({ refreshToken: token });
+    // Token exists in store so it should succeed
+    assert.equal(result.ok, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AUTH-013: Concurrent-refresh lock
+// ---------------------------------------------------------------------------
+
+describe("refresh — concurrent-refresh lock (AUTH-013)", () => {
+  it("returns INVALID_REFRESH_TOKEN when the same token is already in-flight", () => {
+    const token = "h".repeat(36);
+    seedRefreshToken(token, SEED.id);
+    // Simulate an in-flight refresh by pre-populating the lock
+    refreshInFlight.add(token);
+    const result = refresh({ refreshToken: token });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_REFRESH_TOKEN");
+    // Clean up
+    refreshInFlight.delete(token);
+  });
+
+  it("lock is released after a successful refresh", () => {
+    const token = "i".repeat(36);
+    seedRefreshToken(token, SEED.id);
+    refresh({ refreshToken: token });
+    assert.equal(refreshInFlight.has(token), false, "lock released after success");
+  });
+
+  it("lock is released after a failed refresh (expired token)", () => {
+    const token = "j".repeat(36);
+    seedRefreshToken(token, SEED.id, -1);
+    refresh({ refreshToken: token });
+    assert.equal(refreshInFlight.has(token), false, "lock released after failure");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AUTH-013: Store-size cap
+// ---------------------------------------------------------------------------
+
+describe("refresh — store-size cap (AUTH-013)", () => {
+  it("evicts the oldest entry when store reaches STORE_MAX_SIZE", () => {
+    // Fill the store to capacity with synthetic tokens
+    const firstToken = "k".repeat(36);
+    refreshStore.set(firstToken, { accountId: "acct-0", expiresAt: Date.now() + 1_000_000 });
+    for (let i = 1; i < STORE_MAX_SIZE; i++) {
+      refreshStore.set(`tok-${i}-${"0".repeat(30 - String(i).length)}`, {
+        accountId: `acct-${i}`,
+        expiresAt: Date.now() + 1_000_000,
+      });
+    }
+    assert.equal(refreshStore.size, STORE_MAX_SIZE);
+
+    // Trigger issueTokens via a successful refresh — needs a valid seeded token
+    // We'll add one more directly to trigger the cap logic
+    const triggerToken = "l".repeat(36);
+    seedRefreshToken(triggerToken, SEED.id);
+    // Store is now STORE_MAX_SIZE + 1; refresh will evict oldest when issuing new token
+    const result = refresh({ refreshToken: triggerToken });
+    assert.equal(result.ok, true);
+    // Store should not exceed STORE_MAX_SIZE (old token deleted + new token added, oldest evicted)
+    assert.ok(refreshStore.size <= STORE_MAX_SIZE, `store size ${refreshStore.size} exceeds cap`);
+    // The very first token we inserted should have been evicted
+    assert.equal(refreshStore.has(firstToken), false, "oldest entry evicted");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Logout
 // ---------------------------------------------------------------------------
 
 describe("logout — happy path", () => {
   it("revokes a valid refresh token", () => {
-    seedRefreshToken("logout-token", SEED.id);
-    const result = logout({ refreshToken: "logout-token" });
+    const token = "m".repeat(36);
+    seedRefreshToken(token, SEED.id);
+    const result = logout({ refreshToken: token });
     assert.equal(result.ok, true);
-    assert.equal(refreshStore.has("logout-token"), false);
+    assert.equal(refreshStore.has(token), false);
   });
 
   it("is idempotent — revoking an unknown token returns ok:true", () => {
-    const result = logout({ refreshToken: "already-gone" });
+    const result = logout({ refreshToken: "n".repeat(36) });
     assert.equal(result.ok, true);
   });
 
   it("is idempotent — double logout returns ok:true both times", () => {
-    seedRefreshToken("double-logout", SEED.id);
-    const first = logout({ refreshToken: "double-logout" });
-    const second = logout({ refreshToken: "double-logout" });
+    const token = "o".repeat(36);
+    seedRefreshToken(token, SEED.id);
+    const first = logout({ refreshToken: token });
+    const second = logout({ refreshToken: token });
     assert.equal(first.ok, true);
     assert.equal(second.ok, true);
   });
 
   it("after logout, refresh with the same token returns INVALID_REFRESH_TOKEN", () => {
-    seedRefreshToken("post-logout-token", SEED.id);
-    logout({ refreshToken: "post-logout-token" });
-    const result = refresh({ refreshToken: "post-logout-token" });
+    const token = "p".repeat(36);
+    seedRefreshToken(token, SEED.id);
+    logout({ refreshToken: token });
+    const result = refresh({ refreshToken: token });
     assert.equal(result.ok, false);
     if (result.ok) throw new Error("unreachable");
     assert.equal(result.code, "INVALID_REFRESH_TOKEN");

--- a/apps/api/src/auth/session.ts
+++ b/apps/api/src/auth/session.ts
@@ -7,6 +7,16 @@
  * - logout(): revokes refresh token; idempotent — unknown tokens still return ok:true.
  * - refreshStore is the single persistence seam; swap Map for a DB adapter when needed.
  *
+ * Hardening (AUTH-013)
+ * --------------------
+ * - Token-length guard: rejects tokens outside the expected UUID length (36 chars).
+ * - Concurrent-refresh lock: per-token in-flight set prevents double-spend races.
+ * - Store-size cap: refreshStore is bounded to STORE_MAX_SIZE; oldest entry evicted on overflow.
+ *
+ * Instrumentation (AUTH-014)
+ * --------------------------
+ * - All log events include accountId (when known), token prefix (first 8 chars), and latency_ms.
+ *
  * Lifecycle events
  * ----------------
  *   REFRESH_ATTEMPT  → token received
@@ -23,7 +33,7 @@ import type { LogoutInput, LogoutResult, RefreshInput, RefreshResult, SessionErr
 import { refreshStore } from "./login.js";
 
 // ---------------------------------------------------------------------------
-// Structured logger (shared pattern)
+// Structured logger (AUTH-014)
 // ---------------------------------------------------------------------------
 
 type LogLevel = "info" | "warn" | "error";
@@ -33,6 +43,11 @@ function log(level: LogLevel, event: string, data?: Record<string, unknown>): vo
   console[level === "error" ? "error" : "log"](JSON.stringify(entry));
 }
 
+/** First 8 chars of a token — safe to log, not enough to replay. */
+function tokenPrefix(token: string): string {
+  return token.slice(0, 8);
+}
+
 // ---------------------------------------------------------------------------
 // Token helpers (mirrors login.ts — same secret, same algorithm)
 // ---------------------------------------------------------------------------
@@ -40,6 +55,9 @@ function log(level: LogLevel, event: string, data?: Record<string, unknown>): vo
 const JWT_SECRET = process.env.JWT_SECRET ?? "dev-secret-change-in-production";
 const ACCESS_TTL_MS = 15 * 60 * 1000;
 const REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// AUTH-013: cap the in-memory store to prevent unbounded growth
+const STORE_MAX_SIZE = 10_000;
 
 function signJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
@@ -57,60 +75,119 @@ function issueTokens(accountId: string): TokenPair {
     exp: Math.floor((now + ACCESS_TTL_MS) / 1000),
   });
   const refreshToken = randomUUID();
+
+  // AUTH-013: evict oldest entry when store is at capacity
+  if (refreshStore.size >= STORE_MAX_SIZE) {
+    const oldest = refreshStore.keys().next().value;
+    if (oldest !== undefined) refreshStore.delete(oldest);
+  }
+
   refreshStore.set(refreshToken, { accountId, expiresAt: now + REFRESH_TTL_MS });
   return { accessToken, expiresAt, refreshToken };
 }
 
 // ---------------------------------------------------------------------------
-// Refresh (AUTH-012)
+// AUTH-013: Concurrent-refresh lock
+// Prevents two simultaneous requests from both consuming the same token.
+// ---------------------------------------------------------------------------
+
+const refreshInFlight = new Set<string>();
+
+// ---------------------------------------------------------------------------
+// AUTH-013: Token-length guard
+// UUID v4 is always 36 characters (8-4-4-4-12 + 4 hyphens).
+// ---------------------------------------------------------------------------
+
+const EXPECTED_TOKEN_LENGTH = 36;
+
+function isValidTokenShape(token: string): boolean {
+  return token.length === EXPECTED_TOKEN_LENGTH;
+}
+
+// ---------------------------------------------------------------------------
+// Refresh (AUTH-012 / AUTH-013 / AUTH-014)
 // ---------------------------------------------------------------------------
 
 export function refresh(input: RefreshInput): RefreshResult {
-  log("info", "REFRESH_ATTEMPT");
+  const start = Date.now();
+  const prefix = input.refreshToken ? tokenPrefix(input.refreshToken) : "";
+  log("info", "REFRESH_ATTEMPT", { tokenPrefix: prefix });
 
   if (!input.refreshToken || input.refreshToken.trim().length === 0) {
-    log("warn", "REFRESH_INVALID");
+    log("warn", "REFRESH_INVALID", { reason: "empty", latency_ms: Date.now() - start });
     return fail("VALIDATION_ERROR", "refreshToken is required.");
   }
 
+  // AUTH-013: reject tokens that cannot be valid UUIDs
+  if (!isValidTokenShape(input.refreshToken.trim())) {
+    log("warn", "REFRESH_INVALID", { reason: "bad_length", tokenPrefix: prefix, latency_ms: Date.now() - start });
+    return fail("VALIDATION_ERROR", "refreshToken format is invalid.");
+  }
+
+  // AUTH-013: concurrent-refresh lock
+  if (refreshInFlight.has(input.refreshToken)) {
+    log("warn", "REFRESH_INVALID", { reason: "in_flight", tokenPrefix: prefix, latency_ms: Date.now() - start });
+    return fail("INVALID_REFRESH_TOKEN", "Refresh token is already being processed.");
+  }
+
+  refreshInFlight.add(input.refreshToken);
   try {
     const entry = refreshStore.get(input.refreshToken);
 
     if (!entry || Date.now() > entry.expiresAt) {
-      // Clean up expired entry if present
       if (entry) refreshStore.delete(input.refreshToken);
-      log("warn", "REFRESH_EXPIRED");
+      log("warn", "REFRESH_EXPIRED", { tokenPrefix: prefix, latency_ms: Date.now() - start });
       return fail("INVALID_REFRESH_TOKEN", "Refresh token is invalid or has expired.");
     }
 
     // Rotate: delete old token, issue new pair
     refreshStore.delete(input.refreshToken);
     const tokens = issueTokens(entry.accountId);
-    log("info", "REFRESH_OK", { accountId: entry.accountId });
+    log("info", "REFRESH_OK", {
+      accountId: entry.accountId,
+      tokenPrefix: prefix,
+      newTokenPrefix: tokenPrefix(tokens.refreshToken),
+      latency_ms: Date.now() - start,
+    });
     return { ok: true, tokens };
   } catch (err) {
-    log("error", "REFRESH_ERROR", { error: err instanceof Error ? err.message : String(err) });
+    log("error", "REFRESH_ERROR", {
+      tokenPrefix: prefix,
+      error: err instanceof Error ? err.message : String(err),
+      latency_ms: Date.now() - start,
+    });
     return fail("INTERNAL_ERROR", "Refresh failed due to an internal error.");
+  } finally {
+    refreshInFlight.delete(input.refreshToken);
   }
 }
 
 // ---------------------------------------------------------------------------
-// Logout (AUTH-012)
+// Logout (AUTH-012 / AUTH-014)
 // ---------------------------------------------------------------------------
 
 export function logout(input: LogoutInput): LogoutResult {
+  const start = Date.now();
+  const prefix = input.refreshToken ? tokenPrefix(input.refreshToken) : "";
+
   if (!input.refreshToken || input.refreshToken.trim().length === 0) {
-    log("warn", "LOGOUT_INVALID");
+    log("warn", "LOGOUT_INVALID", { reason: "empty", latency_ms: Date.now() - start });
     return fail("VALIDATION_ERROR", "refreshToken is required.");
   }
 
   try {
+    const entry = refreshStore.get(input.refreshToken);
+    const accountId = entry?.accountId;
     // Idempotent: delete regardless of whether token exists
     refreshStore.delete(input.refreshToken);
-    log("info", "LOGOUT_OK");
+    log("info", "LOGOUT_OK", { accountId, tokenPrefix: prefix, latency_ms: Date.now() - start });
     return { ok: true };
   } catch (err) {
-    log("error", "LOGOUT_ERROR", { error: err instanceof Error ? err.message : String(err) });
+    log("error", "LOGOUT_ERROR", {
+      tokenPrefix: prefix,
+      error: err instanceof Error ? err.message : String(err),
+      latency_ms: Date.now() - start,
+    });
     return fail("INTERNAL_ERROR", "Logout failed due to an internal error.");
   }
 }
@@ -118,3 +195,9 @@ export function logout(input: LogoutInput): LogoutResult {
 function fail(code: SessionErrorCode, message: string): { ok: false; code: SessionErrorCode; message: string } {
   return { ok: false, code, message };
 }
+
+/** Exposed for tests — lets tests inspect/manipulate the in-flight lock. */
+export { refreshInFlight };
+
+/** Exposed for tests — store-size cap constant. */
+export { STORE_MAX_SIZE };

--- a/docs/auth-password-reset.md
+++ b/docs/auth-password-reset.md
@@ -1,0 +1,132 @@
+# AUTH-016 — Password Reset and Recovery Workflow
+
+## Overview
+
+This document describes the design for the password reset and recovery flow in the Qyou API. It covers the full lifecycle from reset request through token validation to password update, with explicit failure states and service boundaries.
+
+## Flow
+
+```
+1. POST /api/v1/auth/password-reset/request
+   → validate email
+   → look up account (always respond ok:true to prevent email enumeration)
+   → generate opaque reset token (UUID), store with accountId + expiresAt (15 min)
+   → emit RESET_REQUESTED log event (accountId, tokenPrefix)
+   → [future] send email with reset link containing token
+
+2. POST /api/v1/auth/password-reset/confirm
+   → validate token + newPassword
+   → look up token in resetStore
+   → reject if expired or not found
+   → hash new password, update account record
+   → delete reset token (single-use)
+   → invalidate all active refresh tokens for the account (force re-login)
+   → emit RESET_CONFIRMED log event (accountId, latency_ms)
+```
+
+## Endpoints
+
+### `POST /api/v1/auth/password-reset/request`
+
+**Request body**
+```json
+{ "email": "user@example.com" }
+```
+
+**Response — always 200** (prevents email enumeration)
+```json
+{ "ok": true }
+```
+
+**Failure codes** (only for malformed input)
+
+| HTTP | code | Condition |
+|------|------|-----------|
+| 400 | `VALIDATION_ERROR` | Missing or invalid email format |
+| 500 | `INTERNAL_ERROR` | Unexpected failure |
+
+---
+
+### `POST /api/v1/auth/password-reset/confirm`
+
+**Request body**
+```json
+{
+  "token": "<uuid>",
+  "newPassword": "<min 8 chars>"
+}
+```
+
+**Success — 200**
+```json
+{ "ok": true }
+```
+
+**Failure codes**
+
+| HTTP | code | Condition |
+|------|------|-----------|
+| 400 | `VALIDATION_ERROR` | Missing token or invalid newPassword |
+| 401 | `INVALID_RESET_TOKEN` | Token not found or expired |
+| 500 | `INTERNAL_ERROR` | Unexpected failure |
+
+---
+
+## Data Shape
+
+```typescript
+type ResetEntry = {
+  accountId: string;
+  expiresAt: number; // Unix ms — 15 min from issuance
+};
+
+// resetStore: Map<resetToken, ResetEntry>
+// Bounded to RESET_STORE_MAX_SIZE (1 000) with oldest-entry eviction.
+```
+
+## Failure States
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Unknown email in request | Returns `ok: true` (no enumeration) |
+| Expired reset token | Deleted on first use; returns `INVALID_RESET_TOKEN` |
+| Unknown reset token | Returns `INVALID_RESET_TOKEN` |
+| Token replayed after use | Returns `INVALID_RESET_TOKEN` (single-use) |
+| Weak new password | Returns `VALIDATION_ERROR` before touching the store |
+| Confirm succeeds | All refresh tokens for the account are revoked |
+
+## Service Boundaries
+
+| File | Responsibility |
+|------|---------------|
+| `apps/api/src/auth/password-reset.ts` | `requestReset()` and `confirmReset()` pure service functions |
+| `apps/api/src/index.ts` | Route handlers wiring service to HTTP |
+| `packages/types/src/index.ts` | `PasswordResetRequestResult`, `PasswordResetConfirmResult`, `PasswordResetErrorCode` types |
+| `resetStore` (in `password-reset.ts`) | In-memory Map; swap for a DB adapter with TTL index when persistence is needed |
+
+## Persistence Seam
+
+`resetStore` is the only persistence surface for reset tokens. To add DB-backed reset:
+1. Replace `resetStore.set/get/delete` with async DB calls.
+2. Add a TTL index or scheduled cleanup for expired tokens.
+3. Account password update becomes a DB write instead of an in-memory Map mutation.
+
+## Rate Limiting
+
+- `requestReset` is rate-limited per IP (5 requests / 60 s) to prevent token-flooding attacks.
+- `confirmReset` is rate-limited per token (3 attempts / 60 s) to slow brute-force guessing.
+
+## Verification
+
+```bash
+# Run all auth tests (once password-reset.test.ts is added)
+cd apps/api
+node --import tsx/esm --test src/auth/registration.test.ts src/auth/login.test.ts src/auth/session.test.ts src/auth/password-reset.test.ts
+```
+
+## Implementation Notes
+
+- Reset tokens are opaque UUIDs (same pattern as refresh tokens).
+- Password hashing uses the same `hashPassword()` helper from `registration.ts`.
+- Refresh-token revocation on confirm reuses `refreshStore` from `login.ts` — iterate and delete all entries matching `accountId`.
+- Email delivery is out of scope for this slice; the service emits a `RESET_REQUESTED` log event with the token so contributors can wire any transport (SMTP, SendGrid, etc.) without changing the service layer.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -89,3 +89,28 @@ export type SessionErrorCode =
   | "VALIDATION_ERROR"
   | "INVALID_REFRESH_TOKEN"
   | "INTERNAL_ERROR";
+
+// --- Password Reset (AUTH-016) ---
+
+export type PasswordResetRequestInput = {
+  email: string;
+};
+
+export type PasswordResetRequestResult =
+  | { ok: true }
+  | { ok: false; code: PasswordResetErrorCode; message: string };
+
+export type PasswordResetConfirmInput = {
+  token: string;
+  newPassword: string;
+};
+
+export type PasswordResetConfirmResult =
+  | { ok: true }
+  | { ok: false; code: PasswordResetErrorCode; message: string };
+
+export type PasswordResetErrorCode =
+  | "VALIDATION_ERROR"
+  | "INVALID_RESET_TOKEN"
+  | "RATE_LIMITED"
+  | "INTERNAL_ERROR";


### PR DESCRIPTION
AUTH-013: token-length guard (36-char UUID), concurrent-refresh lock (in-flight Set), store-size cap (10k, oldest-entry eviction)

AUTH-014: enrich all log events with accountId, tokenPrefix (8 chars), and latency_ms for faster diagnosis

AUTH-015: extend session.test.ts — token-length, concurrent-lock, and store-cap suites; 58 tests, 0 failures

AUTH-016: docs/auth-password-reset.md design doc; password-reset.ts service stub (requestReset + confirmReset) with rate-limit, store-cap, and session revocation on confirm; smoke tests; @qyou/types extended

Closes #331, Closes #332, Closes #333, Closes #334