### PR TITLE
feat(auth): email verification and account-activation flow

### DIFF
--- a/apps/api/src/auth/verification.test.ts
+++ b/apps/api/src/auth/verification.test.ts
@@ -1,0 +1,139 @@
+/**
+ * AUTH-021 through AUTH-024 — Email verification lifecycle tests.
+ *
+ * Run with:
+ *   node --import tsx/esm --test src/auth/verification.test.ts
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { verify, issueVerificationToken, verificationStore, clearVerifyRateBuckets } from "./verification.js";
+import { clearAccounts, seedAccount } from "./store.js";
+
+const IP = "1.2.3.4";
+
+function makeAccount(overrides: Partial<{ id: string; email: string; status: "pending_verification" | "active" }> = {}) {
+  return {
+    id: overrides.id ?? "acc-1",
+    email: overrides.email ?? "alice@example.com",
+    passwordHash: "hash",
+    displayName: "Alice",
+    createdAt: new Date().toISOString(),
+    status: overrides.status ?? "pending_verification" as const,
+  };
+}
+
+beforeEach(() => {
+  clearAccounts();
+  verificationStore.clear();
+  clearVerifyRateBuckets();
+});
+
+describe("verify — happy path", () => {
+  it("activates a pending account and returns ok:true", () => {
+    const account = makeAccount();
+    seedAccount(account);
+    const token = issueVerificationToken(account.id);
+
+    const result = verify({ token }, IP);
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.accountId, account.id);
+    assert.equal(result.email, account.email);
+    assert.equal(account.status, "active");
+  });
+
+  it("consumes the token (single-use)", () => {
+    const account = makeAccount();
+    seedAccount(account);
+    const token = issueVerificationToken(account.id);
+
+    verify({ token }, IP);
+    const second = verify({ token }, IP);
+    assert.equal(second.ok, false);
+    if (second.ok) throw new Error("unreachable");
+    assert.equal(second.code, "INVALID_VERIFICATION_TOKEN");
+  });
+});
+
+describe("verify — validation", () => {
+  it("rejects empty token", () => {
+    const result = verify({ token: "" }, IP);
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("rejects token with wrong length", () => {
+    const result = verify({ token: "short" }, IP);
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+});
+
+describe("verify — invalid / expired token", () => {
+  it("returns INVALID_VERIFICATION_TOKEN for unknown token", () => {
+    const fakeToken = "00000000-0000-0000-0000-000000000000";
+    const result = verify({ token: fakeToken }, IP);
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_VERIFICATION_TOKEN");
+  });
+
+  it("returns INVALID_VERIFICATION_TOKEN for expired token", () => {
+    const account = makeAccount();
+    seedAccount(account);
+    const token = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    verificationStore.set(token, { accountId: account.id, expiresAt: Date.now() - 1 });
+
+    const result = verify({ token }, IP);
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_VERIFICATION_TOKEN");
+  });
+});
+
+describe("verify — already verified", () => {
+  it("returns ALREADY_VERIFIED for an active account", () => {
+    const account = makeAccount({ status: "active" });
+    seedAccount(account);
+    const token = issueVerificationToken(account.id);
+
+    const result = verify({ token }, IP);
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "ALREADY_VERIFIED");
+  });
+});
+
+describe("verify — rate limiting", () => {
+  it("returns RATE_LIMITED after 5 attempts from the same IP", () => {
+    for (let i = 0; i < 5; i++) {
+      verify({ token: `0000000${i}-0000-0000-0000-000000000000` }, "9.9.9.9");
+    }
+    const result = verify({ token: "00000099-0000-0000-0000-000000000000" }, "9.9.9.9");
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "RATE_LIMITED");
+  });
+
+  it("allows attempts from a different IP", () => {
+    for (let i = 0; i < 6; i++) {
+      verify({ token: `0000000${i}-0000-0000-0000-000000000000` }, "9.9.9.9");
+    }
+    const account = makeAccount();
+    seedAccount(account);
+    const token = issueVerificationToken(account.id);
+    const result = verify({ token }, "8.8.8.8");
+    assert.equal(result.ok, true);
+  });
+});
+
+describe("issueVerificationToken", () => {
+  it("returns a UUID-shaped token and stores it", () => {
+    const token = issueVerificationToken("acc-1");
+    assert.equal(token.length, 36);
+    assert.ok(verificationStore.has(token));
+  });
+});

--- a/apps/api/src/auth/verification.ts
+++ b/apps/api/src/auth/verification.ts
@@ -1,0 +1,173 @@
+/**
+ * Email Verification & Account Activation (AUTH-021 through AUTH-024).
+ *
+ * Design (AUTH-021)
+ * -----------------
+ * - issueVerificationToken(accountId): generates a UUID token, stores it with TTL.
+ *   Call this after registration; deliver the token out-of-band (email transport TODO).
+ * - verify(token): validates token, flips account status to "active", single-use.
+ * - Store is a Map keyed by token — swap for a DB adapter when persistence is needed.
+ * - Per-IP rate-limit (5 attempts / 60 s) mirrors other auth guards (AUTH-023).
+ * - Token-length guard and concurrent-verify lock prevent replay/race (AUTH-023).
+ * - Store capped at STORE_MAX_SIZE to prevent unbounded growth (AUTH-023).
+ *
+ * Lifecycle events (AUTH-024)
+ * ---------------------------
+ *   VERIFY_ATTEMPT        → token received
+ *   VERIFY_INVALID        → validation failed
+ *   VERIFY_RATE_LIMITED   → IP throttled
+ *   VERIFY_EXPIRED        → token not found or past TTL
+ *   VERIFY_ALREADY_ACTIVE → account already verified
+ *   VERIFY_OK             → account activated
+ *   VERIFY_ERROR          → unexpected failure
+ */
+
+import { randomUUID } from "node:crypto";
+import type { VerificationErrorCode, VerificationInput, VerificationResult } from "@qyou/types";
+import { accountsByEmail } from "./store.js";
+
+// ---------------------------------------------------------------------------
+// Structured logger (AUTH-024)
+// ---------------------------------------------------------------------------
+
+type LogLevel = "info" | "warn" | "error";
+function log(level: LogLevel, event: string, data?: Record<string, unknown>): void {
+  const entry = { ts: new Date().toISOString(), level, event, ...data };
+  // eslint-disable-next-line no-console
+  console[level === "error" ? "error" : "log"](JSON.stringify(entry));
+}
+
+function tokenPrefix(token: string): string {
+  return token.slice(0, 8);
+}
+
+// ---------------------------------------------------------------------------
+// Verification token store (AUTH-022)
+// ---------------------------------------------------------------------------
+
+const TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+export const STORE_MAX_SIZE = 10_000;
+
+type VerifyEntry = { accountId: string; expiresAt: number };
+export const verificationStore = new Map<string, VerifyEntry>();
+
+export function issueVerificationToken(accountId: string): string {
+  const token = randomUUID();
+  if (verificationStore.size >= STORE_MAX_SIZE) {
+    const oldest = verificationStore.keys().next().value;
+    if (oldest !== undefined) verificationStore.delete(oldest);
+  }
+  verificationStore.set(token, { accountId, expiresAt: Date.now() + TOKEN_TTL_MS });
+  return token;
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit (AUTH-023)
+// ---------------------------------------------------------------------------
+
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX = 5;
+const rateBuckets = new Map<string, { count: number; windowStart: number }>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const bucket = rateBuckets.get(ip);
+  if (!bucket || now - bucket.windowStart > RATE_WINDOW_MS) {
+    rateBuckets.set(ip, { count: 1, windowStart: now });
+    return false;
+  }
+  bucket.count += 1;
+  return bucket.count > RATE_MAX;
+}
+
+/** For tests: reset rate-limit state. */
+export function clearVerifyRateBuckets(): void {
+  rateBuckets.clear();
+}
+
+// ---------------------------------------------------------------------------
+// AUTH-023: Concurrent-verify lock — prevents double-spend races
+// ---------------------------------------------------------------------------
+
+const verifyInFlight = new Set<string>();
+
+// UUID v4 is always 36 characters
+const EXPECTED_TOKEN_LENGTH = 36;
+
+// ---------------------------------------------------------------------------
+// Verify service (AUTH-022 / AUTH-023 / AUTH-024)
+// ---------------------------------------------------------------------------
+
+export function verify(input: VerificationInput, ip: string): VerificationResult {
+  const start = Date.now();
+  const prefix = input.token ? tokenPrefix(input.token) : "";
+  log("info", "VERIFY_ATTEMPT", { ip, tokenPrefix: prefix });
+
+  if (!input.token || input.token.trim().length === 0) {
+    log("warn", "VERIFY_INVALID", { ip, reason: "empty", latency_ms: Date.now() - start });
+    return fail("VALIDATION_ERROR", "token is required.");
+  }
+
+  if (input.token.trim().length !== EXPECTED_TOKEN_LENGTH) {
+    log("warn", "VERIFY_INVALID", { ip, reason: "bad_length", tokenPrefix: prefix, latency_ms: Date.now() - start });
+    return fail("VALIDATION_ERROR", "token format is invalid.");
+  }
+
+  if (isRateLimited(ip)) {
+    log("warn", "VERIFY_RATE_LIMITED", { ip, latency_ms: Date.now() - start });
+    return fail("RATE_LIMITED", "Too many verification attempts. Try again later.");
+  }
+
+  if (verifyInFlight.has(input.token)) {
+    log("warn", "VERIFY_INVALID", { ip, reason: "in_flight", tokenPrefix: prefix, latency_ms: Date.now() - start });
+    return fail("INVALID_VERIFICATION_TOKEN", "Verification token is already being processed.");
+  }
+
+  verifyInFlight.add(input.token);
+  try {
+    const entry = verificationStore.get(input.token);
+
+    if (!entry || Date.now() > entry.expiresAt) {
+      if (entry) verificationStore.delete(input.token);
+      log("warn", "VERIFY_EXPIRED", { ip, tokenPrefix: prefix, latency_ms: Date.now() - start });
+      return fail("INVALID_VERIFICATION_TOKEN", "Verification token is invalid or has expired.");
+    }
+
+    const account = [...accountsByEmail.values()].find((a) => a.id === entry.accountId);
+    if (!account) {
+      verificationStore.delete(input.token);
+      log("warn", "VERIFY_EXPIRED", { ip, accountId: entry.accountId, reason: "no_account", latency_ms: Date.now() - start });
+      return fail("INVALID_VERIFICATION_TOKEN", "Verification token is invalid or has expired.");
+    }
+
+    if (account.status === "active") {
+      verificationStore.delete(input.token);
+      log("info", "VERIFY_ALREADY_ACTIVE", { ip, accountId: account.id, latency_ms: Date.now() - start });
+      return fail("ALREADY_VERIFIED", "Account is already verified.");
+    }
+
+    // Activate account — single-use token
+    account.status = "active";
+    verificationStore.delete(input.token);
+
+    log("info", "VERIFY_OK", { accountId: account.id, email: account.email, latency_ms: Date.now() - start });
+    return { ok: true, accountId: account.id, email: account.email };
+  } catch (err) {
+    log("error", "VERIFY_ERROR", {
+      ip,
+      tokenPrefix: prefix,
+      error: err instanceof Error ? err.message : String(err),
+      latency_ms: Date.now() - start,
+    });
+    return fail("INTERNAL_ERROR", "Verification failed due to an internal error.");
+  } finally {
+    verifyInFlight.delete(input.token);
+  }
+}
+
+function fail(code: VerificationErrorCode, message: string): VerificationResult {
+  return { ok: false, code, message };
+}
+
+/** Exposed for tests */
+export { verifyInFlight };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,8 @@ import type { Request, Response } from "express";
 import { register } from "./auth/registration.js";
 import { login } from "./auth/login.js";
 import { refresh, logout } from "./auth/session.js";
-import type { LoginInput, LogoutInput, RefreshInput, RegistrationInput } from "@qyou/types";
+import { verify } from "./auth/verification.js";
+import type { LoginInput, LogoutInput, RefreshInput, RegistrationInput, VerificationInput } from "@qyou/types";
 
 type ServiceStatus = {
   ok: boolean;
@@ -160,6 +161,41 @@ app.post("/api/v1/auth/logout", (request: Request, response: Response) => {
 
   const statusMap: Record<string, number> = {
     VALIDATION_ERROR: 400,
+    INTERNAL_ERROR: 500,
+  };
+
+  response.status(statusMap[result.code] ?? 500).json(result);
+});
+
+/**
+ * POST /api/v1/auth/verify
+ *
+ * Body: { token }
+ * 200  → { ok: true, accountId, email }
+ * 400  → { ok: false, code: "VALIDATION_ERROR" | "ALREADY_VERIFIED", message }
+ * 401  → { ok: false, code: "INVALID_VERIFICATION_TOKEN", message }
+ * 429  → { ok: false, code: "RATE_LIMITED", message }
+ * 500  → { ok: false, code: "INTERNAL_ERROR", message }
+ */
+app.post("/api/v1/auth/verify", (request: Request, response: Response) => {
+  const ip =
+    (request.headers["x-forwarded-for"] as string | undefined)?.split(",")[0]?.trim() ??
+    request.socket.remoteAddress ??
+    "unknown";
+
+  const input = request.body as VerificationInput;
+  const result = verify(input, ip);
+
+  if (result.ok) {
+    response.status(200).json(result);
+    return;
+  }
+
+  const statusMap: Record<string, number> = {
+    VALIDATION_ERROR: 400,
+    ALREADY_VERIFIED: 400,
+    INVALID_VERIFICATION_TOKEN: 401,
+    RATE_LIMITED: 429,
     INTERNAL_ERROR: 500,
   };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -90,6 +90,23 @@ export type SessionErrorCode =
   | "INVALID_REFRESH_TOKEN"
   | "INTERNAL_ERROR";
 
+// --- Email Verification (AUTH-021) ---
+
+export type VerificationInput = {
+  token: string;
+};
+
+export type VerificationResult =
+  | { ok: true; accountId: string; email: string }
+  | { ok: false; code: VerificationErrorCode; message: string };
+
+export type VerificationErrorCode =
+  | "VALIDATION_ERROR"
+  | "INVALID_VERIFICATION_TOKEN"
+  | "ALREADY_VERIFIED"
+  | "RATE_LIMITED"
+  | "INTERNAL_ERROR";
+
 // --- Password Reset (AUTH-016) ---
 
 export type PasswordResetRequestInput = {


### PR DESCRIPTION
Closes #339, closes #340, closes #341, closes #342

Implements the full email verification and account-activation flow across AUTH-021–024.

**Changes**
- `@qyou/types`: `VerificationInput`, `VerificationResult`, `VerificationErrorCode`
- `verification.ts`: `issueVerificationToken` + `verify` service — validates token, activates account
- Hardening: per-IP rate-limit, UUID-length guard, concurrent-verify lock, store cap (10k)
- Instrumentation: structured JSON lifecycle events (`VERIFY_ATTEMPT/OK/EXPIRED/ALREADY_ACTIVE/RATE_LIMITED/ERROR`)
- `POST /api/v1/auth/verify` wired in `index.ts`
- 10 tests: happy path, single-use, validation, expiry, already-verified, rate-limit

**Verified**: `npm run build` passes; all 10 tests pass.