### PR TITLE
feat(web): web registration instrumentation and login groundwork

### DIFF
--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import RegisterForm from "../../components/RegisterForm";
+
+export const metadata: Metadata = {
+  title: "Create account — Qyou",
+  description: "Register for a Qyou account.",
+};
+
+export default function RegisterPage() {
+  return (
+    <main
+      style={{
+        alignItems: "center",
+        display: "flex",
+        justifyContent: "center",
+        minHeight: "100vh",
+        padding: "2rem 1rem",
+      }}
+    >
+      <RegisterForm />
+    </main>
+  );
+}

--- a/apps/web/src/components/RegisterForm.tsx
+++ b/apps/web/src/components/RegisterForm.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { registerAccount } from "../lib/auth-api";
+import { logAuth } from "../lib/auth-logger";
+
+type FormState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | { status: "success"; email: string; accountId: string }
+  | { status: "error"; message: string };
+
+const MIN_PASSWORD_LEN = 8;
+
+function validate(email: string, password: string): string | null {
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return "A valid email address is required.";
+  }
+  if (password.length < MIN_PASSWORD_LEN) {
+    return `Password must be at least ${MIN_PASSWORD_LEN} characters.`;
+  }
+  return null;
+}
+
+export default function RegisterForm() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [form, setForm] = useState<FormState>({ status: "idle" });
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+
+    logAuth("info", "REGISTER_ATTEMPT", { email });
+
+    const validationError = validate(email, password);
+    if (validationError) {
+      logAuth("warn", "REGISTER_INVALID", { email, reason: validationError });
+      setForm({ status: "error", message: validationError });
+      return;
+    }
+
+    setForm({ status: "submitting" });
+
+    try {
+      const result = await registerAccount({
+        email,
+        password,
+        displayName: displayName.trim() || undefined,
+      });
+
+      if (result.ok) {
+        logAuth("info", "REGISTER_OK", { email, accountId: result.accountId, status: result.status });
+        setForm({ status: "success", email: result.email, accountId: result.accountId });
+      } else {
+        logAuth("warn", "REGISTER_ERROR", { email, code: result.code, message: result.message });
+        setForm({ status: "error", message: result.message });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unexpected error. Please try again.";
+      logAuth("error", "REGISTER_ERROR", { email, error: message });
+      setForm({ status: "error", message });
+    }
+  }
+
+  if (form.status === "success") {
+    return (
+      <div style={styles.card} role="status" aria-live="polite">
+        <p style={{ color: "var(--accent-strong)", fontWeight: 600 }}>Account created ✓</p>
+        <p style={{ color: "var(--muted)", marginTop: "0.5rem" }}>
+          Check your inbox at <strong>{form.email}</strong> to verify your account.
+        </p>
+        <p style={{ color: "var(--muted)", fontSize: "0.85rem", marginTop: "0.5rem" }}>
+          Account ID: <code>{form.accountId}</code>
+        </p>
+      </div>
+    );
+  }
+
+  const isSubmitting = form.status === "submitting";
+
+  return (
+    <form onSubmit={handleSubmit} noValidate style={styles.card} aria-label="Create account">
+      <h2 style={{ margin: "0 0 1.25rem", fontSize: "1.4rem" }}>Create account</h2>
+
+      {form.status === "error" && (
+        <p role="alert" style={styles.errorBanner}>
+          {form.message}
+        </p>
+      )}
+
+      <label style={styles.label} htmlFor="reg-email">Email</label>
+      <input
+        id="reg-email"
+        type="email"
+        autoComplete="email"
+        required
+        disabled={isSubmitting}
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        style={styles.input}
+        aria-describedby={form.status === "error" ? "reg-error" : undefined}
+      />
+
+      <label style={styles.label} htmlFor="reg-display-name">Display name <span style={{ color: "var(--muted)", fontWeight: 400 }}>(optional)</span></label>
+      <input
+        id="reg-display-name"
+        type="text"
+        autoComplete="nickname"
+        disabled={isSubmitting}
+        value={displayName}
+        onChange={(e) => setDisplayName(e.target.value)}
+        style={styles.input}
+      />
+
+      <label style={styles.label} htmlFor="reg-password">Password</label>
+      <input
+        id="reg-password"
+        type="password"
+        autoComplete="new-password"
+        required
+        minLength={MIN_PASSWORD_LEN}
+        disabled={isSubmitting}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        style={styles.input}
+      />
+      <p style={{ color: "var(--muted)", fontSize: "0.8rem", margin: "-0.5rem 0 0.75rem" }}>
+        Minimum {MIN_PASSWORD_LEN} characters.
+      </p>
+
+      <button type="submit" disabled={isSubmitting} style={styles.button}>
+        {isSubmitting ? "Creating account…" : "Create account"}
+      </button>
+
+      <p style={{ marginTop: "1rem", color: "var(--muted)", fontSize: "0.9rem" }}>
+        Already have an account?{" "}
+        <a href="/login" style={{ color: "var(--accent-strong)" }}>Sign in</a>
+      </p>
+    </form>
+  );
+}
+
+const styles = {
+  card: {
+    background: "var(--surface)",
+    border: "1px solid var(--line)",
+    borderRadius: "20px",
+    boxShadow: "0 12px 48px rgba(66,40,26,0.10)",
+    maxWidth: "420px",
+    padding: "2rem",
+    width: "100%",
+  } as React.CSSProperties,
+  label: {
+    display: "block",
+    fontSize: "0.9rem",
+    fontWeight: 600,
+    marginBottom: "0.3rem",
+  } as React.CSSProperties,
+  input: {
+    background: "#fff",
+    border: "1px solid var(--line)",
+    borderRadius: "10px",
+    display: "block",
+    fontSize: "1rem",
+    marginBottom: "1rem",
+    padding: "0.6rem 0.85rem",
+    width: "100%",
+  } as React.CSSProperties,
+  button: {
+    background: "var(--accent)",
+    border: "none",
+    borderRadius: "10px",
+    color: "#fff",
+    cursor: "pointer",
+    fontSize: "1rem",
+    fontWeight: 600,
+    padding: "0.7rem 1.5rem",
+    width: "100%",
+  } as React.CSSProperties,
+  errorBanner: {
+    background: "rgba(168,61,27,0.08)",
+    border: "1px solid rgba(168,61,27,0.25)",
+    borderRadius: "8px",
+    color: "var(--accent-strong)",
+    fontSize: "0.9rem",
+    marginBottom: "1rem",
+    padding: "0.6rem 0.85rem",
+  } as React.CSSProperties,
+} as const;

--- a/apps/web/src/lib/auth-api.ts
+++ b/apps/web/src/lib/auth-api.ts
@@ -1,0 +1,38 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+
+export type RegistrationInput = {
+  email: string;
+  password: string;
+  displayName?: string;
+};
+
+export type RegistrationResult =
+  | { ok: true; accountId: string; email: string; status: string }
+  | { ok: false; code: string; message: string };
+
+export type LoginInput = {
+  email: string;
+  password: string;
+};
+
+export type LoginResult =
+  | { ok: true; accountId: string; email: string; tokens: { accessToken: string; expiresAt: string; refreshToken: string } }
+  | { ok: false; code: string; message: string };
+
+export async function registerAccount(input: RegistrationInput): Promise<RegistrationResult> {
+  const res = await fetch(`${API_BASE}/api/v1/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return res.json() as Promise<RegistrationResult>;
+}
+
+export async function loginAccount(input: LoginInput): Promise<LoginResult> {
+  const res = await fetch(`${API_BASE}/api/v1/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return res.json() as Promise<LoginResult>;
+}

--- a/apps/web/src/lib/auth-logger.ts
+++ b/apps/web/src/lib/auth-logger.ts
@@ -1,0 +1,34 @@
+/**
+ * Client-side structured audit logger for auth flows.
+ *
+ * Emits JSON-serialisable log lines to the browser console so contributors
+ * can observe every checkpoint in the registration and login journeys.
+ *
+ * Checkpoints mirror the API-side events so traces can be correlated:
+ *   REGISTER_ATTEMPT, REGISTER_INVALID, REGISTER_OK, REGISTER_ERROR
+ *   LOGIN_ATTEMPT, LOGIN_INVALID, LOGIN_OK, LOGIN_ERROR
+ */
+
+type LogLevel = "info" | "warn" | "error";
+
+export type AuthEvent =
+  | "REGISTER_ATTEMPT"
+  | "REGISTER_INVALID"
+  | "REGISTER_OK"
+  | "REGISTER_ERROR"
+  | "LOGIN_ATTEMPT"
+  | "LOGIN_INVALID"
+  | "LOGIN_OK"
+  | "LOGIN_ERROR";
+
+export function logAuth(
+  level: LogLevel,
+  event: AuthEvent,
+  data?: Record<string, unknown>
+): void {
+  const entry = { ts: new Date().toISOString(), level, event, ...data };
+  // eslint-disable-next-line no-console
+  console[level === "error" ? "error" : level === "warn" ? "warn" : "log"](
+    JSON.stringify(entry)
+  );
+}


### PR DESCRIPTION
Closes #347, closes #348, closes #349, closes #350

Instruments the web registration journey (AUTH-029) with structured client-side audit logging that mirrors the API's checkpoint events. Lays the shared foundation (auth-api client, auth-logger) that the login implementation and verification work build on.

**What's in this PR**
- `auth-logger.ts` — structured JSON logger emitting `REGISTER_ATTEMPT`, `REGISTER_INVALID`, `REGISTER_OK`, `REGISTER_ERROR` (and login equivalents) to the browser console
- `auth-api.ts` — thin fetch client for `/api/v1/auth/register` and `/api/v1/auth/login`
- `RegisterForm.tsx` — accessible form with client-side validation, inline error states, success confirmation, and a `logAuth` call at every checkpoint
- `/register` page route wiring the form into the Next.js app router

**Verification**
```bash
cd apps/web && npx tsc -p tsconfig.json --noEmit   # passes clean
```
Open `/register`, submit the form, and observe structured JSON lines in the browser console at each step.