### PR TITLE
Auth Surface Baseline: Hardened Web Login + Instrumented Checkpoints + Reset Blueprint

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import LoginForm from "../../../src/components/LoginForm";
+
+export const metadata: Metadata = {
+  title: "Login — Qyou",
+  description: "Sign in to Qyou.",
+};
+
+export default function LoginPage() {
+  return (
+    <main style={{ maxWidth: 480, margin: "4rem auto", padding: "1rem" }}>
+      <h1>Sign in</h1>
+      <LoginForm />
+    </main>
+  );
+}

--- a/apps/web/src/components/LoginForm.tsx
+++ b/apps/web/src/components/LoginForm.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { loginAccount } from "../lib/auth-api";
+import { logAuth } from "../lib/auth-logger";
+
+const MIN_PASSWORD_LEN = 8;
+
+type State =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | { status: "success"; email: string }
+  | { status: "error"; message: string };
+
+function validate(email: string, password: string): string | null {
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return "Enter a valid email.";
+  if (password.length < MIN_PASSWORD_LEN) return `Password must be at least ${MIN_PASSWORD_LEN} characters.`;
+  return null;
+}
+
+export default function LoginForm() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [state, setState] = useState<State>({ status: "idle" });
+  const [lastSubmitMs, setLastSubmitMs] = useState(0);
+  const [showReset, setShowReset] = useState(false);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    const now = Date.now();
+    if (now - lastSubmitMs < 1200) {
+      setState({ status: "error", message: "Please wait a moment before retrying." });
+      return;
+    }
+    setLastSubmitMs(now);
+
+    logAuth("info", "LOGIN_ATTEMPT", { email });
+    const invalid = validate(email, password);
+    if (invalid) {
+      logAuth("warn", "LOGIN_INVALID", { email, reason: invalid });
+      setState({ status: "error", message: invalid });
+      return;
+    }
+
+    setState({ status: "submitting" });
+    try {
+      const result = await loginAccount({ email, password });
+      if (result.ok) {
+        logAuth("info", "LOGIN_OK", { email, accountId: result.accountId });
+        setState({ status: "success", email: result.email });
+        setPassword("");
+      } else {
+        logAuth("warn", "LOGIN_ERROR", { email, code: result.code, message: result.message });
+        setState({ status: "error", message: "Invalid credentials or unavailable session. Please try again." });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unexpected login error.";
+      logAuth("error", "LOGIN_ERROR", { email, error: message });
+      setState({ status: "error", message: "Unable to sign in right now. Please retry." });
+    }
+  }
+
+  if (state.status === "success") {
+    return <p role="status">Signed in as {state.email}. Session established.</p>;
+  }
+
+  return (
+    <form onSubmit={onSubmit} noValidate aria-label="Login">
+      {state.status === "error" && <p role="alert">{state.message}</p>}
+      <label htmlFor="login-email">Email</label>
+      <input id="login-email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      <label htmlFor="login-password">Password</label>
+      <input id="login-password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+      <button type="submit" disabled={state.status === "submitting"}>
+        {state.status === "submitting" ? "Signing in..." : "Sign in"}
+      </button>
+      <button type="button" onClick={() => setShowReset((v) => !v)}>
+        Forgot password?
+      </button>
+      {showReset && (
+        <section aria-live="polite">
+          <p>Password reset flow</p>
+          <ol>
+            <li>Submit account email.</li>
+            <li>Receive reset link token in email.</li>
+            <li>Open reset link and set a new password.</li>
+            <li>Re-login with new credentials.</li>
+          </ol>
+          <p>Failure states: unknown email, expired token, weak password, replayed token.</p>
+        </section>
+      )}
+    </form>
+  );
+}

--- a/docs/auth-password-reset.md
+++ b/docs/auth-password-reset.md
@@ -130,3 +130,35 @@ node --import tsx/esm --test src/auth/registration.test.ts src/auth/login.test.t
 - Password hashing uses the same `hashPassword()` helper from `registration.ts`.
 - Refresh-token revocation on confirm reuses `refreshStore` from `login.ts` — iterate and delete all entries matching `accountId`.
 - Email delivery is out of scope for this slice; the service emits a `RESET_REQUESTED` log event with the token so contributors can wire any transport (SMTP, SendGrid, etc.) without changing the service layer.
+# Web Password Reset Experience (AUTH-036)
+
+## Target Flow
+1. User selects `Forgot password?` from the web login page.
+2. User submits account email (request-reset endpoint).
+3. System sends single-use tokenized reset link.
+4. User opens link and submits new password.
+5. Backend validates token, password policy, and token freshness.
+6. Success returns login prompt; failure returns non-enumerating error.
+
+## Boundaries
+- Web login page only exposes flow states and guidance.
+- Token generation, verification, and invalidation remain API-owned.
+- Web should never reveal whether an email exists.
+
+## Failure States
+- Invalid/unknown email request.
+- Expired token.
+- Replayed token.
+- Weak password.
+- Network/API outage.
+
+## Route/Data Contract
+- `POST /api/v1/auth/password-reset/request` body: `{ email: string }`
+- `POST /api/v1/auth/password-reset/confirm` body: `{ token: string, password: string }`
+- Standard response shape:
+  - success: `{ ok: true }`
+  - error: `{ ok: false, code: string, message: string }`
+
+## Verification Notes
+- From `/login`, toggle password reset section and verify all flow/failure states are visible.
+- Confirm login logger emits checkpoints (`LOGIN_ATTEMPT`, `LOGIN_INVALID`, `LOGIN_OK`, `LOGIN_ERROR`).


### PR DESCRIPTION
## Summary
Minimal FE auth slice for assigned backlog items.

### Included
- Added `/login` page and `LoginForm` with:
  - client-side validation
  - submit throttling guard to reduce rapid replay spam
  - safe generic error handling and password clear-on-success
  - structured auth instrumentation (`LOGIN_ATTEMPT`, `LOGIN_INVALID`, `LOGIN_OK`, `LOGIN_ERROR`)
- Added inline password reset UX blueprint section in login flow.
- Updated password reset design doc with target flow, boundaries, failure states, contracts, and verification notes.

## Verification
- Open `/login` and validate: invalid input handling, submit guardrails, instrumentation logs, reset flow states.

Closes #351
Closes #352
Closes #353
Closes #354
