### PR TITLE
Web reset confidence pass: implementation, abuse guardrails, instrumentation, and verification notes

### DIFF
--- a/apps/web/src/components/LoginForm.tsx
+++ b/apps/web/src/components/LoginForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
-import { loginAccount } from "../lib/auth-api";
+import { confirmPasswordReset, loginAccount, requestPasswordReset } from "../lib/auth-api";
 import { logAuth } from "../lib/auth-logger";
 
 const MIN_PASSWORD_LEN = 8;
@@ -24,6 +24,10 @@ export default function LoginForm() {
   const [state, setState] = useState<State>({ status: "idle" });
   const [lastSubmitMs, setLastSubmitMs] = useState(0);
   const [showReset, setShowReset] = useState(false);
+  const [resetEmail, setResetEmail] = useState("");
+  const [resetToken, setResetToken] = useState("");
+  const [resetPassword, setResetPassword] = useState("");
+  const [resetMsg, setResetMsg] = useState("");
 
   async function onSubmit(e: FormEvent) {
     e.preventDefault();
@@ -80,13 +84,61 @@ export default function LoginForm() {
       {showReset && (
         <section aria-live="polite">
           <p>Password reset flow</p>
-          <ol>
-            <li>Submit account email.</li>
-            <li>Receive reset link token in email.</li>
-            <li>Open reset link and set a new password.</li>
-            <li>Re-login with new credentials.</li>
-          </ol>
-          <p>Failure states: unknown email, expired token, weak password, replayed token.</p>
+          <label htmlFor="reset-email">Reset email</label>
+          <input id="reset-email" type="email" value={resetEmail} onChange={(e) => setResetEmail(e.target.value)} />
+          <button
+            type="button"
+            onClick={async () => {
+              logAuth("info", "RESET_REQUEST_ATTEMPT", { email: resetEmail });
+              try {
+                const result = await requestPasswordReset(resetEmail);
+                if (result.ok) {
+                  setResetMsg("If the email exists, a reset link has been sent.");
+                  logAuth("info", "RESET_REQUEST_OK", { email: resetEmail });
+                } else {
+                  setResetMsg("Unable to process reset request.");
+                  logAuth("warn", "RESET_REQUEST_ERROR", { code: result.code });
+                }
+              } catch {
+                setResetMsg("Network error while requesting reset.");
+                logAuth("error", "RESET_REQUEST_ERROR", { reason: "network" });
+              }
+            }}
+          >
+            Request reset
+          </button>
+          <label htmlFor="reset-token">Reset token</label>
+          <input id="reset-token" type="text" value={resetToken} onChange={(e) => setResetToken(e.target.value)} />
+          <label htmlFor="reset-password">New password</label>
+          <input id="reset-password" type="password" value={resetPassword} onChange={(e) => setResetPassword(e.target.value)} />
+          <button
+            type="button"
+            onClick={async () => {
+              if (resetPassword.length < MIN_PASSWORD_LEN) {
+                setResetMsg(`Password must be at least ${MIN_PASSWORD_LEN} characters.`);
+                return;
+              }
+              logAuth("info", "RESET_CONFIRM_ATTEMPT", {});
+              try {
+                const result = await confirmPasswordReset(resetToken, resetPassword);
+                if (result.ok) {
+                  setResetMsg("Password reset complete. Sign in with your new password.");
+                  setResetToken("");
+                  setResetPassword("");
+                  logAuth("info", "RESET_CONFIRM_OK", {});
+                } else {
+                  setResetMsg("Reset token is invalid or expired.");
+                  logAuth("warn", "RESET_CONFIRM_ERROR", { code: result.code });
+                }
+              } catch {
+                setResetMsg("Network error while confirming reset.");
+                logAuth("error", "RESET_CONFIRM_ERROR", { reason: "network" });
+              }
+            }}
+          >
+            Confirm reset
+          </button>
+          {resetMsg && <p role="status">{resetMsg}</p>}
         </section>
       )}
     </form>

--- a/apps/web/src/lib/auth-api.ts
+++ b/apps/web/src/lib/auth-api.ts
@@ -19,6 +19,9 @@ export type LoginResult =
   | { ok: true; accountId: string; email: string; tokens: { accessToken: string; expiresAt: string; refreshToken: string } }
   | { ok: false; code: string; message: string };
 
+export type ResetRequestResult = { ok: true } | { ok: false; code: string; message: string };
+export type ResetConfirmResult = { ok: true } | { ok: false; code: string; message: string };
+
 export async function registerAccount(input: RegistrationInput): Promise<RegistrationResult> {
   const res = await fetch(`${API_BASE}/api/v1/auth/register`, {
     method: "POST",
@@ -35,4 +38,22 @@ export async function loginAccount(input: LoginInput): Promise<LoginResult> {
     body: JSON.stringify(input),
   });
   return res.json() as Promise<LoginResult>;
+}
+
+export async function requestPasswordReset(email: string): Promise<ResetRequestResult> {
+  const res = await fetch(`${API_BASE}/api/v1/auth/password-reset/request`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
+  });
+  return res.json() as Promise<ResetRequestResult>;
+}
+
+export async function confirmPasswordReset(token: string, newPassword: string): Promise<ResetConfirmResult> {
+  const res = await fetch(`${API_BASE}/api/v1/auth/password-reset/confirm`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token, newPassword }),
+  });
+  return res.json() as Promise<ResetConfirmResult>;
 }

--- a/apps/web/src/lib/auth-logger.ts
+++ b/apps/web/src/lib/auth-logger.ts
@@ -19,7 +19,13 @@ export type AuthEvent =
   | "LOGIN_ATTEMPT"
   | "LOGIN_INVALID"
   | "LOGIN_OK"
-  | "LOGIN_ERROR";
+  | "LOGIN_ERROR"
+  | "RESET_REQUEST_ATTEMPT"
+  | "RESET_REQUEST_OK"
+  | "RESET_REQUEST_ERROR"
+  | "RESET_CONFIRM_ATTEMPT"
+  | "RESET_CONFIRM_OK"
+  | "RESET_CONFIRM_ERROR";
 
 export function logAuth(
   level: LogLevel,

--- a/docs/auth-password-reset.md
+++ b/docs/auth-password-reset.md
@@ -162,3 +162,6 @@ node --import tsx/esm --test src/auth/registration.test.ts src/auth/login.test.t
 ## Verification Notes
 - From `/login`, toggle password reset section and verify all flow/failure states are visible.
 - Confirm login logger emits checkpoints (`LOGIN_ATTEMPT`, `LOGIN_INVALID`, `LOGIN_OK`, `LOGIN_ERROR`).
+- Confirm reset instrumentation emits:
+  - `RESET_REQUEST_ATTEMPT`, `RESET_REQUEST_OK|RESET_REQUEST_ERROR`
+  - `RESET_CONFIRM_ATTEMPT`, `RESET_CONFIRM_OK|RESET_CONFIRM_ERROR`


### PR DESCRIPTION
## Summary
This PR delivers a minimal but complete web password-reset slice for the assigned AUTH-037..040 set.

## Included
- Added web API helpers for reset request and reset confirm.
- Implemented reset request/confirm UI in the login reset section.
- Added frontend guardrail validation for new password length and stable user-facing error handling for invalid/expired tokens.
- Added structured auth checkpoints for reset flow instrumentation.
- Updated password-reset verification notes with explicit instrumentation checkpoints.

## Notes
- Scope stays intentionally small and modular within the web workspace.

Closes #355
Closes #356
Closes #357
Closes #358