### PR TITLE
feat(stellar-service): wallet link/unlink/rotate/recovery (AUTH-092, AUTH-093)

### DIFF
--- a/apps/stellar-service/src/index.ts
+++ b/apps/stellar-service/src/index.ts
@@ -1,5 +1,14 @@
 import express from "express";
+import type { Request, Response } from "express";
 import { Horizon } from "@stellar/stellar-sdk";
+import { link, unlink, rotate, initiateRecovery, confirmRecovery } from "./wallet-link.js";
+import type {
+  WalletLinkInput,
+  WalletUnlinkInput,
+  WalletRotateInput,
+  WalletRecoveryInitInput,
+  WalletRecoveryConfirmInput,
+} from "@qyou/types";
 
 type ServiceStatus = {
   ok: boolean;
@@ -19,6 +28,7 @@ const rpcUrl = process.env.STELLAR_RPC_URL ?? "https://soroban-testnet.stellar.o
 const horizonServer = new Horizon.Server("https://horizon-testnet.stellar.org");
 
 const app = express();
+app.use(express.json());
 
 app.get("/health", (_request, response) => {
   const payload: ServiceStatus = {
@@ -39,6 +49,157 @@ app.get("/api/v1/stellar/info", async (_request, response) => {
   };
 
   response.json(payload);
+});
+
+/**
+ * POST /api/v1/stellar/wallet/link
+ *
+ * Body: { accountId, walletAddress }
+ * 201  → { ok: true, accountId, walletAddress, linkedAt }
+ * 400  → { ok: false, code: "VALIDATION_ERROR" | "ALREADY_LINKED", message }
+ * 429  → { ok: false, code: "RATE_LIMITED", message }
+ * 500  → { ok: false, code: "INTERNAL_ERROR", message }
+ */
+app.post("/api/v1/stellar/wallet/link", (request: Request, response: Response) => {
+  const input = request.body as WalletLinkInput;
+  const result = link(input);
+
+  if (result.ok) {
+    response.status(201).json(result);
+    return;
+  }
+
+  const statusMap: Record<string, number> = {
+    VALIDATION_ERROR: 400,
+    ALREADY_LINKED: 409,
+    NOT_LINKED: 404,
+    INVALID_RECOVERY_TOKEN: 401,
+    RATE_LIMITED: 429,
+    INTERNAL_ERROR: 500,
+  };
+
+  response.status(statusMap[result.code] ?? 500).json(result);
+});
+
+/**
+ * POST /api/v1/stellar/wallet/unlink
+ *
+ * Body: { accountId }
+ * 200  → { ok: true }
+ * 400  → { ok: false, code: "VALIDATION_ERROR", message }
+ * 404  → { ok: false, code: "NOT_LINKED", message }
+ * 500  → { ok: false, code: "INTERNAL_ERROR", message }
+ */
+app.post("/api/v1/stellar/wallet/unlink", (request: Request, response: Response) => {
+  const input = request.body as WalletUnlinkInput;
+  const result = unlink(input);
+
+  if (result.ok) {
+    response.status(200).json(result);
+    return;
+  }
+
+  const statusMap: Record<string, number> = {
+    VALIDATION_ERROR: 400,
+    ALREADY_LINKED: 409,
+    NOT_LINKED: 404,
+    INVALID_RECOVERY_TOKEN: 401,
+    RATE_LIMITED: 429,
+    INTERNAL_ERROR: 500,
+  };
+
+  response.status(statusMap[result.code] ?? 500).json(result);
+});
+
+/**
+ * POST /api/v1/stellar/wallet/rotate
+ *
+ * Body: { accountId, newWalletAddress }
+ * 200  → { ok: true, accountId, walletAddress, rotatedAt }
+ * 400  → { ok: false, code: "VALIDATION_ERROR", message }
+ * 404  → { ok: false, code: "NOT_LINKED", message }
+ * 429  → { ok: false, code: "RATE_LIMITED", message }
+ * 500  → { ok: false, code: "INTERNAL_ERROR", message }
+ */
+app.post("/api/v1/stellar/wallet/rotate", (request: Request, response: Response) => {
+  const input = request.body as WalletRotateInput;
+  const result = rotate(input);
+
+  if (result.ok) {
+    response.status(200).json(result);
+    return;
+  }
+
+  const statusMap: Record<string, number> = {
+    VALIDATION_ERROR: 400,
+    ALREADY_LINKED: 409,
+    NOT_LINKED: 404,
+    INVALID_RECOVERY_TOKEN: 401,
+    RATE_LIMITED: 429,
+    INTERNAL_ERROR: 500,
+  };
+
+  response.status(statusMap[result.code] ?? 500).json(result);
+});
+
+/**
+ * POST /api/v1/stellar/wallet/recovery/initiate
+ *
+ * Body: { accountId }
+ * 200  → { ok: true, recoveryToken, expiresAt }
+ * 400  → { ok: false, code: "VALIDATION_ERROR", message }
+ * 429  → { ok: false, code: "RATE_LIMITED", message }
+ * 500  → { ok: false, code: "INTERNAL_ERROR", message }
+ */
+app.post("/api/v1/stellar/wallet/recovery/initiate", (request: Request, response: Response) => {
+  const input = request.body as WalletRecoveryInitInput;
+  const result = initiateRecovery(input);
+
+  if (result.ok) {
+    response.status(200).json(result);
+    return;
+  }
+
+  const statusMap: Record<string, number> = {
+    VALIDATION_ERROR: 400,
+    ALREADY_LINKED: 409,
+    NOT_LINKED: 404,
+    INVALID_RECOVERY_TOKEN: 401,
+    RATE_LIMITED: 429,
+    INTERNAL_ERROR: 500,
+  };
+
+  response.status(statusMap[result.code] ?? 500).json(result);
+});
+
+/**
+ * POST /api/v1/stellar/wallet/recovery/confirm
+ *
+ * Body: { accountId, recoveryToken, newWalletAddress }
+ * 200  → { ok: true, accountId, walletAddress }
+ * 400  → { ok: false, code: "VALIDATION_ERROR", message }
+ * 401  → { ok: false, code: "INVALID_RECOVERY_TOKEN", message }
+ * 500  → { ok: false, code: "INTERNAL_ERROR", message }
+ */
+app.post("/api/v1/stellar/wallet/recovery/confirm", (request: Request, response: Response) => {
+  const input = request.body as WalletRecoveryConfirmInput;
+  const result = confirmRecovery(input);
+
+  if (result.ok) {
+    response.status(200).json(result);
+    return;
+  }
+
+  const statusMap: Record<string, number> = {
+    VALIDATION_ERROR: 400,
+    ALREADY_LINKED: 409,
+    NOT_LINKED: 404,
+    INVALID_RECOVERY_TOKEN: 401,
+    RATE_LIMITED: 429,
+    INTERNAL_ERROR: 500,
+  };
+
+  response.status(statusMap[result.code] ?? 500).json(result);
 });
 
 app.listen(port, () => {

--- a/apps/stellar-service/src/wallet-link.test.ts
+++ b/apps/stellar-service/src/wallet-link.test.ts
@@ -1,0 +1,473 @@
+/**
+ * AUTH-092 / AUTH-093 — Wallet link, unlink, rotate, and recovery tests.
+ *
+ * Run with:
+ *   node --import tsx/esm --test src/wallet-link.test.ts
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  link,
+  unlink,
+  rotate,
+  initiateRecovery,
+  confirmRecovery,
+  walletStore,
+  recoveryStore,
+  rotateInFlight,
+  clearRateBuckets,
+  STORE_MAX_SIZE,
+  RECOVERY_TTL_MS,
+} from "./wallet-link.js";
+
+// Valid 56-char Stellar public key format (G + 55 base32 chars)
+const VALID_ADDRESS = "GBVVJJWAKWYMKWMQHWOMTEKOVUA36TYVWRECQ7YGPMXWYE5VWHUWMXNB";
+const VALID_ADDRESS_2 = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+function resetAll(): void {
+  walletStore.clear();
+  recoveryStore.clear();
+  rotateInFlight.clear();
+  clearRateBuckets();
+}
+
+beforeEach(resetAll);
+
+// ---------------------------------------------------------------------------
+// link — happy path
+// ---------------------------------------------------------------------------
+
+describe("link — happy path", () => {
+  it("links a wallet and returns ok:true with accountId, walletAddress, linkedAt", () => {
+    const result = link({ accountId: "acct-1", walletAddress: VALID_ADDRESS });
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.accountId, "acct-1");
+    assert.equal(result.walletAddress, VALID_ADDRESS);
+    assert.ok(result.linkedAt, "linkedAt is set");
+    assert.ok(new Date(result.linkedAt) <= new Date(), "linkedAt is not in the future");
+  });
+
+  it("persists the record in walletStore", () => {
+    link({ accountId: "acct-2", walletAddress: VALID_ADDRESS });
+    assert.ok(walletStore.has("acct-2"));
+    assert.equal(walletStore.get("acct-2")?.walletAddress, VALID_ADDRESS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// link — validation
+// ---------------------------------------------------------------------------
+
+describe("link — validation", () => {
+  it("returns VALIDATION_ERROR for missing accountId", () => {
+    const result = link({ accountId: "", walletAddress: VALID_ADDRESS });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns VALIDATION_ERROR for missing walletAddress", () => {
+    const result = link({ accountId: "acct-3", walletAddress: "" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns VALIDATION_ERROR for invalid Stellar address (too short)", () => {
+    const result = link({ accountId: "acct-4", walletAddress: "GABC" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns VALIDATION_ERROR for address not starting with G", () => {
+    const result = link({ accountId: "acct-5", walletAddress: "S" + "A".repeat(55) });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns ALREADY_LINKED when a wallet is already linked", () => {
+    link({ accountId: "acct-6", walletAddress: VALID_ADDRESS });
+    const result = link({ accountId: "acct-6", walletAddress: VALID_ADDRESS_2 });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "ALREADY_LINKED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// link — rate-limit (AUTH-093)
+// ---------------------------------------------------------------------------
+
+describe("link — rate-limit (AUTH-093)", () => {
+  it("returns RATE_LIMITED after exceeding 5 attempts per accountId", () => {
+    for (let i = 0; i < 5; i++) {
+      link({ accountId: "acct-rl", walletAddress: VALID_ADDRESS });
+    }
+    const result = link({ accountId: "acct-rl", walletAddress: VALID_ADDRESS });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "RATE_LIMITED");
+  });
+
+  it("rate-limit is per-accountId — different accounts are independent", () => {
+    for (let i = 0; i < 5; i++) {
+      link({ accountId: "acct-rl2", walletAddress: VALID_ADDRESS });
+    }
+    // Different account should not be rate-limited
+    const result = link({ accountId: "acct-other", walletAddress: VALID_ADDRESS });
+    // May fail for other reasons (already linked etc.) but not RATE_LIMITED
+    if (!result.ok) {
+      assert.notEqual(result.code, "RATE_LIMITED");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unlink — happy path
+// ---------------------------------------------------------------------------
+
+describe("unlink — happy path", () => {
+  it("unlinks a wallet and returns ok:true", () => {
+    link({ accountId: "acct-7", walletAddress: VALID_ADDRESS });
+    const result = unlink({ accountId: "acct-7" });
+    assert.equal(result.ok, true);
+    assert.equal(walletStore.has("acct-7"), false);
+  });
+
+  it("cleans up pending recovery tokens on unlink", () => {
+    link({ accountId: "acct-8", walletAddress: VALID_ADDRESS });
+    const initResult = initiateRecovery({ accountId: "acct-8" });
+    assert.equal(initResult.ok, true);
+    if (!initResult.ok) throw new Error("unreachable");
+    const token = initResult.recoveryToken;
+    unlink({ accountId: "acct-8" });
+    assert.equal(recoveryStore.has(token), false, "recovery token cleaned up on unlink");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unlink — validation
+// ---------------------------------------------------------------------------
+
+describe("unlink — validation", () => {
+  it("returns VALIDATION_ERROR for missing accountId", () => {
+    const result = unlink({ accountId: "" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns NOT_LINKED when no wallet is linked", () => {
+    const result = unlink({ accountId: "acct-9" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "NOT_LINKED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotate — happy path
+// ---------------------------------------------------------------------------
+
+describe("rotate — happy path", () => {
+  it("rotates to a new wallet address and returns ok:true", () => {
+    link({ accountId: "acct-10", walletAddress: VALID_ADDRESS });
+    const result = rotate({ accountId: "acct-10", newWalletAddress: VALID_ADDRESS_2 });
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.walletAddress, VALID_ADDRESS_2);
+    assert.ok(result.rotatedAt, "rotatedAt is set");
+  });
+
+  it("updates the walletStore with the new address", () => {
+    link({ accountId: "acct-11", walletAddress: VALID_ADDRESS });
+    rotate({ accountId: "acct-11", newWalletAddress: VALID_ADDRESS_2 });
+    assert.equal(walletStore.get("acct-11")?.walletAddress, VALID_ADDRESS_2);
+  });
+
+  it("preserves the original linkedAt timestamp after rotation", () => {
+    link({ accountId: "acct-12", walletAddress: VALID_ADDRESS });
+    const originalLinkedAt = walletStore.get("acct-12")!.linkedAt;
+    rotate({ accountId: "acct-12", newWalletAddress: VALID_ADDRESS_2 });
+    assert.equal(walletStore.get("acct-12")?.linkedAt, originalLinkedAt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotate — validation
+// ---------------------------------------------------------------------------
+
+describe("rotate — validation", () => {
+  it("returns VALIDATION_ERROR for missing accountId", () => {
+    const result = rotate({ accountId: "", newWalletAddress: VALID_ADDRESS_2 });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns VALIDATION_ERROR for invalid new wallet address", () => {
+    link({ accountId: "acct-13", walletAddress: VALID_ADDRESS });
+    const result = rotate({ accountId: "acct-13", newWalletAddress: "INVALID" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns NOT_LINKED when no wallet is linked", () => {
+    const result = rotate({ accountId: "acct-14", newWalletAddress: VALID_ADDRESS_2 });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "NOT_LINKED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotate — concurrent-rotation lock (AUTH-093)
+// ---------------------------------------------------------------------------
+
+describe("rotate — concurrent-rotation lock (AUTH-093)", () => {
+  it("returns INTERNAL_ERROR when a rotation is already in-flight", () => {
+    link({ accountId: "acct-15", walletAddress: VALID_ADDRESS });
+    rotateInFlight.add("acct-15");
+    const result = rotate({ accountId: "acct-15", newWalletAddress: VALID_ADDRESS_2 });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INTERNAL_ERROR");
+    rotateInFlight.delete("acct-15");
+  });
+
+  it("lock is released after a successful rotation", () => {
+    link({ accountId: "acct-16", walletAddress: VALID_ADDRESS });
+    rotate({ accountId: "acct-16", newWalletAddress: VALID_ADDRESS_2 });
+    assert.equal(rotateInFlight.has("acct-16"), false, "lock released after success");
+  });
+
+  it("lock is released after a failed rotation (not linked)", () => {
+    rotate({ accountId: "acct-17", newWalletAddress: VALID_ADDRESS_2 });
+    assert.equal(rotateInFlight.has("acct-17"), false, "lock released after failure");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// initiateRecovery — happy path
+// ---------------------------------------------------------------------------
+
+describe("initiateRecovery — happy path", () => {
+  it("returns ok:true with a recoveryToken and expiresAt", () => {
+    const result = initiateRecovery({ accountId: "acct-18" });
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.ok(result.recoveryToken.length > 0, "recoveryToken is set");
+    assert.ok(new Date(result.expiresAt) > new Date(), "expiresAt is in the future");
+  });
+
+  it("stores the recovery token in recoveryStore", () => {
+    const result = initiateRecovery({ accountId: "acct-19" });
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.ok(recoveryStore.has(result.recoveryToken));
+  });
+
+  it("invalidates any previous recovery token when a new one is issued", () => {
+    const first = initiateRecovery({ accountId: "acct-20" });
+    assert.equal(first.ok, true);
+    if (!first.ok) throw new Error("unreachable");
+    const firstToken = first.recoveryToken;
+
+    const second = initiateRecovery({ accountId: "acct-20" });
+    assert.equal(second.ok, true);
+    if (!second.ok) throw new Error("unreachable");
+
+    assert.equal(recoveryStore.has(firstToken), false, "old token invalidated");
+    assert.ok(recoveryStore.has(second.recoveryToken), "new token stored");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// initiateRecovery — validation
+// ---------------------------------------------------------------------------
+
+describe("initiateRecovery — validation", () => {
+  it("returns VALIDATION_ERROR for missing accountId", () => {
+    const result = initiateRecovery({ accountId: "" });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// confirmRecovery — happy path
+// ---------------------------------------------------------------------------
+
+describe("confirmRecovery — happy path", () => {
+  it("confirms recovery and sets the new wallet address", () => {
+    const init = initiateRecovery({ accountId: "acct-21" });
+    assert.equal(init.ok, true);
+    if (!init.ok) throw new Error("unreachable");
+
+    const result = confirmRecovery({
+      accountId: "acct-21",
+      recoveryToken: init.recoveryToken,
+      newWalletAddress: VALID_ADDRESS,
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.walletAddress, VALID_ADDRESS);
+    assert.equal(walletStore.get("acct-21")?.walletAddress, VALID_ADDRESS);
+  });
+
+  it("recovery token is consumed (single-use)", () => {
+    const init = initiateRecovery({ accountId: "acct-22" });
+    assert.equal(init.ok, true);
+    if (!init.ok) throw new Error("unreachable");
+
+    confirmRecovery({
+      accountId: "acct-22",
+      recoveryToken: init.recoveryToken,
+      newWalletAddress: VALID_ADDRESS,
+    });
+
+    // Second use of the same token should fail
+    const second = confirmRecovery({
+      accountId: "acct-22",
+      recoveryToken: init.recoveryToken,
+      newWalletAddress: VALID_ADDRESS_2,
+    });
+    assert.equal(second.ok, false);
+    if (second.ok) throw new Error("unreachable");
+    assert.equal(second.code, "INVALID_RECOVERY_TOKEN");
+  });
+
+  it("preserves original linkedAt when recovering over an existing link", () => {
+    link({ accountId: "acct-23", walletAddress: VALID_ADDRESS });
+    const originalLinkedAt = walletStore.get("acct-23")!.linkedAt;
+
+    const init = initiateRecovery({ accountId: "acct-23" });
+    assert.equal(init.ok, true);
+    if (!init.ok) throw new Error("unreachable");
+
+    confirmRecovery({
+      accountId: "acct-23",
+      recoveryToken: init.recoveryToken,
+      newWalletAddress: VALID_ADDRESS_2,
+    });
+
+    assert.equal(walletStore.get("acct-23")?.linkedAt, originalLinkedAt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// confirmRecovery — validation and security (AUTH-093)
+// ---------------------------------------------------------------------------
+
+describe("confirmRecovery — validation and security (AUTH-093)", () => {
+  it("returns VALIDATION_ERROR for missing accountId", () => {
+    const result = confirmRecovery({ accountId: "", recoveryToken: "tok", newWalletAddress: VALID_ADDRESS });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns VALIDATION_ERROR for missing recoveryToken", () => {
+    const result = confirmRecovery({ accountId: "acct-24", recoveryToken: "", newWalletAddress: VALID_ADDRESS });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns VALIDATION_ERROR for invalid new wallet address", () => {
+    const init = initiateRecovery({ accountId: "acct-25" });
+    assert.equal(init.ok, true);
+    if (!init.ok) throw new Error("unreachable");
+    const result = confirmRecovery({
+      accountId: "acct-25",
+      recoveryToken: init.recoveryToken,
+      newWalletAddress: "INVALID",
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "VALIDATION_ERROR");
+  });
+
+  it("returns INVALID_RECOVERY_TOKEN for unknown token", () => {
+    const result = confirmRecovery({
+      accountId: "acct-26",
+      recoveryToken: "00000000-0000-0000-0000-000000000000",
+      newWalletAddress: VALID_ADDRESS,
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_RECOVERY_TOKEN");
+  });
+
+  it("returns INVALID_RECOVERY_TOKEN when token belongs to a different account (AUTH-093)", () => {
+    const init = initiateRecovery({ accountId: "acct-27" });
+    assert.equal(init.ok, true);
+    if (!init.ok) throw new Error("unreachable");
+
+    // Try to use acct-27's token for acct-28
+    const result = confirmRecovery({
+      accountId: "acct-28",
+      recoveryToken: init.recoveryToken,
+      newWalletAddress: VALID_ADDRESS,
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_RECOVERY_TOKEN");
+    // Token should still be valid for the correct account
+    assert.ok(recoveryStore.has(init.recoveryToken), "token not consumed on wrong-account attempt");
+  });
+
+  it("returns INVALID_RECOVERY_TOKEN for an expired token (AUTH-093)", () => {
+    const accountId = "acct-29";
+    const token = "expired-token-uuid-1234567890123456";
+    // Manually insert an expired token
+    recoveryStore.set(token, { accountId, expiresAt: Date.now() - 1 });
+
+    const result = confirmRecovery({
+      accountId,
+      recoveryToken: token,
+      newWalletAddress: VALID_ADDRESS,
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.code, "INVALID_RECOVERY_TOKEN");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store-size cap (AUTH-093)
+// ---------------------------------------------------------------------------
+
+describe("store-size cap (AUTH-093)", () => {
+  it("walletStore does not exceed STORE_MAX_SIZE", () => {
+    // Fill to capacity
+    for (let i = 0; i < STORE_MAX_SIZE; i++) {
+      walletStore.set(`acct-cap-${i}`, {
+        accountId: `acct-cap-${i}`,
+        walletAddress: VALID_ADDRESS,
+        linkedAt: new Date().toISOString(),
+      });
+    }
+    assert.equal(walletStore.size, STORE_MAX_SIZE);
+
+    // One more link should evict the oldest
+    link({ accountId: "acct-cap-new", walletAddress: VALID_ADDRESS });
+    assert.ok(walletStore.size <= STORE_MAX_SIZE, `store size ${walletStore.size} exceeds cap`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Recovery TTL constant sanity check
+// ---------------------------------------------------------------------------
+
+describe("RECOVERY_TTL_MS", () => {
+  it("is 15 minutes", () => {
+    assert.equal(RECOVERY_TTL_MS, 15 * 60 * 1000);
+  });
+});

--- a/apps/stellar-service/src/wallet-link.ts
+++ b/apps/stellar-service/src/wallet-link.ts
@@ -1,0 +1,394 @@
+/**
+ * Wallet Link — link, unlink, rotate, and account-recovery service.
+ *
+ * AUTH-092: Core behaviour
+ * ------------------------
+ * - link()            Associate a Stellar wallet address with an accountId.
+ * - unlink()          Remove the wallet association.
+ * - rotate()          Atomically swap to a new wallet address.
+ * - initiateRecovery() Issue a short-lived recovery token for a locked-out account.
+ * - confirmRecovery()  Consume the recovery token and set a new wallet address.
+ *
+ * AUTH-093: Hardening
+ * -------------------
+ * - Stellar address validation (56-char G… public key format).
+ * - Per-accountId rate-limit on link/rotate/recovery operations (5 / 60 s).
+ * - Recovery tokens are single-use UUIDs with a 15-minute TTL.
+ * - Concurrent-rotation lock prevents double-spend races.
+ * - Store bounded to STORE_MAX_SIZE; oldest entry evicted on overflow.
+ * - All operations emit structured JSON log events with latency_ms.
+ *
+ * Lifecycle events
+ * ----------------
+ *   WALLET_LINK_ATTEMPT / WALLET_LINK_OK / WALLET_LINK_ERROR
+ *   WALLET_UNLINK_ATTEMPT / WALLET_UNLINK_OK / WALLET_UNLINK_ERROR
+ *   WALLET_ROTATE_ATTEMPT / WALLET_ROTATE_OK / WALLET_ROTATE_ERROR
+ *   WALLET_RECOVERY_INIT_ATTEMPT / WALLET_RECOVERY_INIT_OK / WALLET_RECOVERY_INIT_ERROR
+ *   WALLET_RECOVERY_CONFIRM_ATTEMPT / WALLET_RECOVERY_CONFIRM_OK / WALLET_RECOVERY_CONFIRM_ERROR
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  WalletLinkErrorCode,
+  WalletLinkInput,
+  WalletLinkRecord,
+  WalletLinkResult,
+  WalletRecoveryConfirmInput,
+  WalletRecoveryConfirmResult,
+  WalletRecoveryInitInput,
+  WalletRecoveryInitResult,
+  WalletRotateInput,
+  WalletRotateResult,
+  WalletUnlinkInput,
+  WalletUnlinkResult,
+} from "@qyou/types";
+
+// ---------------------------------------------------------------------------
+// Structured logger
+// ---------------------------------------------------------------------------
+
+type LogLevel = "info" | "warn" | "error";
+function log(level: LogLevel, event: string, data?: Record<string, unknown>): void {
+  const entry = { ts: new Date().toISOString(), level, event, ...data };
+  // eslint-disable-next-line no-console
+  console[level === "error" ? "error" : "log"](JSON.stringify(entry));
+}
+
+// ---------------------------------------------------------------------------
+// In-memory store (AUTH-093: bounded)
+// ---------------------------------------------------------------------------
+
+export const STORE_MAX_SIZE = 10_000;
+
+/** Primary store: accountId → WalletLinkRecord */
+export const walletStore = new Map<string, WalletLinkRecord>();
+
+/** Recovery token store: recoveryToken → accountId */
+const recoveryStore = new Map<string, { accountId: string; expiresAt: number }>();
+
+function evictIfFull(store: Map<string, unknown>): void {
+  if (store.size >= STORE_MAX_SIZE) {
+    const oldest = store.keys().next().value;
+    if (oldest !== undefined) store.delete(oldest);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AUTH-093: Per-accountId rate-limit
+// ---------------------------------------------------------------------------
+
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX = 5;
+const rateBuckets = new Map<string, { count: number; windowStart: number }>();
+
+function isRateLimited(accountId: string): boolean {
+  const now = Date.now();
+  const bucket = rateBuckets.get(accountId);
+  if (!bucket || now - bucket.windowStart > RATE_WINDOW_MS) {
+    rateBuckets.set(accountId, { count: 1, windowStart: now });
+    return false;
+  }
+  bucket.count += 1;
+  return bucket.count > RATE_MAX;
+}
+
+/** For tests: reset rate-limit state. */
+export function clearRateBuckets(): void {
+  rateBuckets.clear();
+}
+
+// ---------------------------------------------------------------------------
+// AUTH-093: Concurrent-rotation lock
+// ---------------------------------------------------------------------------
+
+const rotateInFlight = new Set<string>();
+
+// ---------------------------------------------------------------------------
+// AUTH-093: Stellar address validation
+// Stellar public keys are 56-character strings starting with 'G'.
+// ---------------------------------------------------------------------------
+
+const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
+
+function isValidStellarAddress(address: string): boolean {
+  return STELLAR_ADDRESS_RE.test(address);
+}
+
+// ---------------------------------------------------------------------------
+// Recovery token TTL
+// ---------------------------------------------------------------------------
+
+const RECOVERY_TTL_MS = 15 * 60 * 1000; // 15 minutes
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fail(code: WalletLinkErrorCode, message: string): { ok: false; code: WalletLinkErrorCode; message: string } {
+  return { ok: false, code, message };
+}
+
+function validateAccountId(accountId: unknown): string | null {
+  if (!accountId || typeof accountId !== "string" || accountId.trim().length === 0) {
+    return "accountId is required.";
+  }
+  return null;
+}
+
+function validateWalletAddress(address: unknown): string | null {
+  if (!address || typeof address !== "string" || address.trim().length === 0) {
+    return "walletAddress is required.";
+  }
+  if (!isValidStellarAddress(address.trim())) {
+    return "walletAddress must be a valid Stellar public key (56-char G… format).";
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// link (AUTH-092)
+// ---------------------------------------------------------------------------
+
+export function link(input: WalletLinkInput): WalletLinkResult {
+  const start = Date.now();
+  const accountId = input.accountId?.trim();
+  log("info", "WALLET_LINK_ATTEMPT", { accountId });
+
+  const accountErr = validateAccountId(accountId);
+  if (accountErr) {
+    log("warn", "WALLET_LINK_ERROR", { reason: "invalid_account", latency_ms: Date.now() - start });
+    return fail("VALIDATION_ERROR", accountErr);
+  }
+
+  const addressErr = validateWalletAddress(input.walletAddress);
+  if (addressErr) {
+    log("warn", "WALLET_LINK_ERROR", { accountId, reason: "invalid_address", latency_ms: Date.now() - start });
+    return fail("VALIDATION_ERROR", addressErr);
+  }
+
+  if (isRateLimited(accountId)) {
+    log("warn", "WALLET_LINK_ERROR", { accountId, reason: "rate_limited", latency_ms: Date.now() - start });
+    return fail("RATE_LIMITED", "Too many wallet operations. Try again later.");
+  }
+
+  if (walletStore.has(accountId)) {
+    log("warn", "WALLET_LINK_ERROR", { accountId, reason: "already_linked", latency_ms: Date.now() - start });
+    return fail("ALREADY_LINKED", "A wallet is already linked to this account. Use rotate to change it.");
+  }
+
+  try {
+    const walletAddress = input.walletAddress.trim();
+    const linkedAt = new Date().toISOString();
+    const record: WalletLinkRecord = { accountId, walletAddress, linkedAt };
+    evictIfFull(walletStore);
+    walletStore.set(accountId, record);
+    log("info", "WALLET_LINK_OK", { accountId, walletAddress, latency_ms: Date.now() - start });
+    return { ok: true, accountId, walletAddress, linkedAt };
+  } catch (err) {
+    log("error", "WALLET_LINK_ERROR", { accountId, error: err instanceof Error ? err.message : String(err), latency_ms: Date.now() - start });
+    return fail("INTERNAL_ERROR", "Wallet link failed due to an internal error.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// unlink (AUTH-092)
+// ---------------------------------------------------------------------------
+
+export function unlink(input: WalletUnlinkInput): WalletUnlinkResult {
+  const start = Date.now();
+  const accountId = input.accountId?.trim();
+  log("info", "WALLET_UNLINK_ATTEMPT", { accountId });
+
+  const accountErr = validateAccountId(accountId);
+  if (accountErr) {
+    log("warn", "WALLET_UNLINK_ERROR", { reason: "invalid_account", latency_ms: Date.now() - start });
+    return fail("VALIDATION_ERROR", accountErr);
+  }
+
+  if (!walletStore.has(accountId)) {
+    log("warn", "WALLET_UNLINK_ERROR", { accountId, reason: "not_linked", latency_ms: Date.now() - start });
+    return fail("NOT_LINKED", "No wallet is linked to this account.");
+  }
+
+  try {
+    walletStore.delete(accountId);
+    // Clean up any pending recovery tokens for this account
+    for (const [token, entry] of recoveryStore) {
+      if (entry.accountId === accountId) recoveryStore.delete(token);
+    }
+    log("info", "WALLET_UNLINK_OK", { accountId, latency_ms: Date.now() - start });
+    return { ok: true };
+  } catch (err) {
+    log("error", "WALLET_UNLINK_ERROR", { accountId, error: err instanceof Error ? err.message : String(err), latency_ms: Date.now() - start });
+    return fail("INTERNAL_ERROR", "Wallet unlink failed due to an internal error.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// rotate (AUTH-092 / AUTH-093)
+// ---------------------------------------------------------------------------
+
+export function rotate(input: WalletRotateInput): WalletRotateResult {
+  const start = Date.now();
+  const accountId = input.accountId?.trim();
+  log("info", "WALLET_ROTATE_ATTEMPT", { accountId });
+
+  const accountErr = validateAccountId(accountId);
+  if (accountErr) {
+    log("warn", "WALLET_ROTATE_ERROR", { reason: "invalid_account", latency_ms: Date.now() - start });
+    return fail("VALIDATION_ERROR", accountErr);
+  }
+
+  const addressErr = validateWalletAddress(input.newWalletAddress);
+  if (addressErr) {
+    log("warn", "WALLET_ROTATE_ERROR", { accountId, reason: "invalid_address", latency_ms: Date.now() - start });
+    return fail("VALIDATION_ERROR", addressErr);
+  }
+
+  if (isRateLimited(accountId)) {
+    log("warn", "WALLET_ROTATE_ERROR", { accountId, reason: "rate_limited", latency_ms: Date.now() - start });
+    return fail("RATE_LIMITED", "Too many wallet operations. Try again later.");
+  }
+
+  if (!walletStore.has(accountId)) {
+    log("warn", "WALLET_ROTATE_ERROR", { accountId, reason: "not_linked", latency_ms: Date.now() - start });
+    return fail("NOT_LINKED", "No wallet is linked to this account. Use link first.");
+  }
+
+  // AUTH-093: concurrent-rotation lock
+  if (rotateInFlight.has(accountId)) {
+    log("warn", "WALLET_ROTATE_ERROR", { accountId, reason: "in_flight", latency_ms: Date.now() - start });
+    return fail("INTERNAL_ERROR", "A rotation is already in progress for this account.");
+  }
+
+  rotateInFlight.add(accountId);
+  try {
+    const existing = walletStore.get(accountId)!;
+    const newWalletAddress = input.newWalletAddress.trim();
+    const rotatedAt = new Date().toISOString();
+    const updated: WalletLinkRecord = {
+      ...existing,
+      walletAddress: newWalletAddress,
+      rotatedAt,
+    };
+    walletStore.set(accountId, updated);
+    log("info", "WALLET_ROTATE_OK", { accountId, newWalletAddress, latency_ms: Date.now() - start });
+    return { ok: true, accountId, walletAddress: newWalletAddress, rotatedAt };
+  } catch (err) {
+    log("error", "WALLET_ROTATE_ERROR", { accountId, error: err instanceof Error ? err.message : String(err), latency_ms: Date.now() - start });
+    return fail("INTERNAL_ERROR", "Wallet rotation failed due to an internal error.");
+  } finally {
+    rotateInFlight.delete(accountId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// initiateRecovery (AUTH-092 / AUTH-093)
+// ---------------------------------------------------------------------------
+
+export function initiateRecovery(input: WalletRecoveryInitInput): WalletRecoveryInitResult {
+  const start = Date.now();
+  const accountId = input.accountId?.trim();
+  log("info", "WALLET_RECOVERY_INIT_ATTEMPT", { accountId });
+
+  const accountErr = validateAccountId(accountId);
+  if (accountErr) {
+    log("warn", "WALLET_RECOVERY_INIT_ERROR", { reason: "invalid_account", latency_ms: Date.now() - start });
+    return fail("VALIDATION_ERROR", accountErr);
+  }
+
+  if (isRateLimited(accountId)) {
+    log("warn", "WALLET_RECOVERY_INIT_ERROR", { accountId, reason: "rate_limited", latency_ms: Date.now() - start });
+    return fail("RATE_LIMITED", "Too many wallet operations. Try again later.");
+  }
+
+  try {
+    // Invalidate any existing recovery token for this account
+    for (const [token, entry] of recoveryStore) {
+      if (entry.accountId === accountId) recoveryStore.delete(token);
+    }
+
+    const recoveryToken = randomUUID();
+    const expiresAt = Date.now() + RECOVERY_TTL_MS;
+    evictIfFull(recoveryStore);
+    recoveryStore.set(recoveryToken, { accountId, expiresAt });
+
+    // Persist token reference on the wallet record if one exists
+    const record = walletStore.get(accountId);
+    if (record) {
+      walletStore.set(accountId, { ...record, recoveryToken, recoveryExpiresAt: expiresAt });
+    }
+
+    const expiresAtIso = new Date(expiresAt).toISOString();
+    log("info", "WALLET_RECOVERY_INIT_OK", { accountId, latency_ms: Date.now() - start });
+    return { ok: true, recoveryToken, expiresAt: expiresAtIso };
+  } catch (err) {
+    log("error", "WALLET_RECOVERY_INIT_ERROR", { accountId, error: err instanceof Error ? err.message : String(err), latency_ms: Date.now() - start });
+    return fail("INTERNAL_ERROR", "Recovery initiation failed due to an internal error.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// confirmRecovery (AUTH-092 / AUTH-093)
+// ---------------------------------------------------------------------------
+
+export function confirmRecovery(input: WalletRecoveryConfirmInput): WalletRecoveryConfirmResult {
+  const start = Date.now();
+  const accountId = input.accountId?.trim();
+  log("info", "WALLET_RECOVERY_CONFIRM_ATTEMPT", { accountId });
+
+  const accountErr = validateAccountId(accountId);
+  if (accountErr) {
+    log("warn", "WALLET_RECOVERY_CONFIRM_ERROR", { reason: "invalid_account", latency_ms: Date.now() - start });
+    return fail("VALIDATION_ERROR", accountErr);
+  }
+
+  if (!input.recoveryToken || input.recoveryToken.trim().length === 0) {
+    log("warn", "WALLET_RECOVERY_CONFIRM_ERROR", { accountId, reason: "missing_token", latency_ms: Date.now() - start });
+    return fail("VALIDATION_ERROR", "recoveryToken is required.");
+  }
+
+  const addressErr = validateWalletAddress(input.newWalletAddress);
+  if (addressErr) {
+    log("warn", "WALLET_RECOVERY_CONFIRM_ERROR", { accountId, reason: "invalid_address", latency_ms: Date.now() - start });
+    return fail("VALIDATION_ERROR", addressErr);
+  }
+
+  try {
+    const entry = recoveryStore.get(input.recoveryToken.trim());
+
+    // AUTH-093: single-use + expiry check + account binding
+    if (!entry || Date.now() > entry.expiresAt || entry.accountId !== accountId) {
+      if (entry && entry.accountId === accountId) recoveryStore.delete(input.recoveryToken.trim());
+      log("warn", "WALLET_RECOVERY_CONFIRM_ERROR", { accountId, reason: "invalid_token", latency_ms: Date.now() - start });
+      return fail("INVALID_RECOVERY_TOKEN", "Recovery token is invalid, expired, or does not match this account.");
+    }
+
+    // Consume the token (single-use)
+    recoveryStore.delete(input.recoveryToken.trim());
+
+    const newWalletAddress = input.newWalletAddress.trim();
+    const now = new Date().toISOString();
+    const existing = walletStore.get(accountId);
+    const record: WalletLinkRecord = {
+      accountId,
+      walletAddress: newWalletAddress,
+      linkedAt: existing?.linkedAt ?? now,
+      rotatedAt: now,
+    };
+    evictIfFull(walletStore);
+    walletStore.set(accountId, record);
+
+    log("info", "WALLET_RECOVERY_CONFIRM_OK", { accountId, newWalletAddress, latency_ms: Date.now() - start });
+    return { ok: true, accountId, walletAddress: newWalletAddress };
+  } catch (err) {
+    log("error", "WALLET_RECOVERY_CONFIRM_ERROR", { accountId, error: err instanceof Error ? err.message : String(err), latency_ms: Date.now() - start });
+    return fail("INTERNAL_ERROR", "Recovery confirmation failed due to an internal error.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports for tests
+// ---------------------------------------------------------------------------
+
+export { recoveryStore, rotateInFlight, RECOVERY_TTL_MS };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -107,6 +107,69 @@ export type VerificationErrorCode =
   | "RATE_LIMITED"
   | "INTERNAL_ERROR";
 
+// --- Stellar Wallet Link (AUTH-092 / AUTH-093) ---
+
+export type WalletLinkRecord = {
+  accountId: string;
+  walletAddress: string;
+  linkedAt: string;       // ISO-8601
+  rotatedAt?: string;     // ISO-8601, set on each rotation
+  recoveryToken?: string; // opaque UUID, set when recovery is initiated
+  recoveryExpiresAt?: number; // Unix ms
+};
+
+export type WalletLinkInput = {
+  accountId: string;
+  walletAddress: string;
+};
+
+export type WalletUnlinkInput = {
+  accountId: string;
+};
+
+export type WalletRotateInput = {
+  accountId: string;
+  newWalletAddress: string;
+};
+
+export type WalletRecoveryInitInput = {
+  accountId: string;
+};
+
+export type WalletRecoveryConfirmInput = {
+  accountId: string;
+  recoveryToken: string;
+  newWalletAddress: string;
+};
+
+export type WalletLinkResult =
+  | { ok: true; accountId: string; walletAddress: string; linkedAt: string }
+  | { ok: false; code: WalletLinkErrorCode; message: string };
+
+export type WalletUnlinkResult =
+  | { ok: true }
+  | { ok: false; code: WalletLinkErrorCode; message: string };
+
+export type WalletRotateResult =
+  | { ok: true; accountId: string; walletAddress: string; rotatedAt: string }
+  | { ok: false; code: WalletLinkErrorCode; message: string };
+
+export type WalletRecoveryInitResult =
+  | { ok: true; recoveryToken: string; expiresAt: string }
+  | { ok: false; code: WalletLinkErrorCode; message: string };
+
+export type WalletRecoveryConfirmResult =
+  | { ok: true; accountId: string; walletAddress: string }
+  | { ok: false; code: WalletLinkErrorCode; message: string };
+
+export type WalletLinkErrorCode =
+  | "VALIDATION_ERROR"
+  | "ALREADY_LINKED"
+  | "NOT_LINKED"
+  | "INVALID_RECOVERY_TOKEN"
+  | "RATE_LIMITED"
+  | "INTERNAL_ERROR";
+
 // --- Password Reset (AUTH-016) ---
 
 export type PasswordResetRequestInput = {


### PR DESCRIPTION
## Summary

Implements the full wallet lifecycle in `apps/stellar-service` across two issues.

### AUTH-092 — Core behaviour
- `link()` — associate a Stellar wallet address with an accountId
- `unlink()` — remove the wallet association
- `rotate()` — atomically swap to a new wallet address
- `initiateRecovery()` — issue a short-lived single-use recovery token
- `confirmRecovery()` — consume the token and set a new wallet address

### AUTH-093 — Hardening
- Stellar address validation (56-char G… base32 format)
- Per-accountId rate-limit (5 ops / 60 s)
- Concurrent-rotation lock prevents double-spend races
- Recovery tokens are single-use UUIDs with 15-min TTL
- Account-binding check on `confirmRecovery` (token cannot be used cross-account)
- In-memory stores bounded to `STORE_MAX_SIZE` (10 000), oldest entry evicted on overflow
- Structured JSON log events with `latency_ms` on every operation

## Routes added to stellar-service
```
POST /api/v1/stellar/wallet/link
POST /api/v1/stellar/wallet/unlink
POST /api/v1/stellar/wallet/rotate
POST /api/v1/stellar/wallet/recovery/initiate
POST /api/v1/stellar/wallet/recovery/confirm
```

## Files changed
- `packages/types/src/index.ts` — wallet-link types
- `apps/stellar-service/src/wallet-link.ts` — service implementation
- `apps/stellar-service/src/wallet-link.test.ts` — 37 tests, 0 failures
- `apps/stellar-service/src/index.ts` — routes wired

## Tested
37 tests pass. Typecheck clean for `packages/types` and `apps/stellar-service`.

Closes #410
Closes #411