### PR TITLE
feat(auth): shared baseline checks + wallet recovery design

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npm run dev:stellar-service
 
 ```bash
 npm run build
+npm run auth:baseline
 npm run typecheck
 npm run lint
 ```

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@qyou/config": "*",
     "@qyou/types": "*",
     "cors": "^2.8.5",
     "express": "^5.1.0"

--- a/apps/api/src/auth/login.ts
+++ b/apps/api/src/auth/login.ts
@@ -22,6 +22,7 @@
 
 import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 import type { AccountRecord, LoginErrorCode, LoginInput, LoginResult, TokenPair } from "@qyou/types";
+import { loadAuthConfig } from "@qyou/config";
 import { getAccountByEmail } from "./store.js";
 
 // ---------------------------------------------------------------------------
@@ -63,9 +64,10 @@ export function clearLoginRateBuckets(): void {
 // JWT (no external dep) (AUTH-007)
 // ---------------------------------------------------------------------------
 
-const JWT_SECRET = process.env.JWT_SECRET ?? "dev-secret-change-in-production";
-const ACCESS_TTL_MS = 15 * 60 * 1000;
-const REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const authConfig = loadAuthConfig();
+const JWT_SECRET = authConfig.jwtSecret;
+const ACCESS_TTL_MS = authConfig.accessTokenTtlSeconds * 1000;
+const REFRESH_TTL_MS = authConfig.refreshTokenTtlSeconds * 1000;
 
 function signJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");

--- a/apps/api/src/auth/session.ts
+++ b/apps/api/src/auth/session.ts
@@ -30,6 +30,7 @@
 
 import { createHash, randomUUID } from "node:crypto";
 import type { LogoutInput, LogoutResult, RefreshInput, RefreshResult, SessionErrorCode, TokenPair } from "@qyou/types";
+import { loadAuthConfig } from "@qyou/config";
 import { refreshStore } from "./login.js";
 
 // ---------------------------------------------------------------------------
@@ -52,9 +53,10 @@ function tokenPrefix(token: string): string {
 // Token helpers (mirrors login.ts — same secret, same algorithm)
 // ---------------------------------------------------------------------------
 
-const JWT_SECRET = process.env.JWT_SECRET ?? "dev-secret-change-in-production";
-const ACCESS_TTL_MS = 15 * 60 * 1000;
-const REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const authConfig = loadAuthConfig();
+const JWT_SECRET = authConfig.jwtSecret;
+const ACCESS_TTL_MS = authConfig.accessTokenTtlSeconds * 1000;
+const REFRESH_TTL_MS = authConfig.refreshTokenTtlSeconds * 1000;
 
 // AUTH-013: cap the in-memory store to prevent unbounded growth
 const STORE_MAX_SIZE = 10_000;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import cors from "cors";
 import express from "express";
 import type { Request, Response } from "express";
+import { getAuthBaselineReport, loadAuthConfig, loadNodeServiceConfig } from "@qyou/config";
 import { register } from "./auth/registration.js";
 import { login } from "./auth/login.js";
 import { refresh, logout } from "./auth/session.js";
@@ -19,12 +20,28 @@ type AuthBootstrap = {
   sessionStrategy: "jwt";
 };
 
-const port = Number(process.env.PORT ?? 4000);
-const corsOrigin = process.env.CORS_ORIGIN ?? "http://localhost:3000";
+const serviceConfig = loadNodeServiceConfig({ defaultPort: 4000, serviceName: "api" });
+
+// AUTH-102/103/104: baseline check for shared auth config across workspaces.
+const baseline = getAuthBaselineReport();
+for (const warning of baseline.warnings) {
+  // eslint-disable-next-line no-console
+  console.warn(JSON.stringify({ level: "warn", event: "auth.baseline.warning", warning, ts: new Date().toISOString() }));
+}
+if (!baseline.ok) {
+  for (const error of baseline.errors) {
+    // eslint-disable-next-line no-console
+    console.error(JSON.stringify({ level: "error", event: "auth.baseline.error", error, ts: new Date().toISOString() }));
+  }
+  throw new Error("Shared auth baseline validation failed.");
+}
+
+// Ensure authConfig is loaded early (and validated) on startup.
+loadAuthConfig();
 
 const app = express();
 
-app.use(cors({ origin: corsOrigin }));
+app.use(cors({ origin: serviceConfig.corsOrigin }));
 app.use(express.json());
 
 app.get("/health", (_request, response) => {
@@ -202,6 +219,6 @@ app.post("/api/v1/auth/verify", (request: Request, response: Response) => {
   response.status(statusMap[result.code] ?? 500).json(result);
 });
 
-app.listen(port, () => {
-  console.log(`[api] listening on http://localhost:${port}`);
+app.listen(serviceConfig.port, () => {
+  console.log(`[api] listening on http://localhost:${serviceConfig.port}`);
 });

--- a/apps/stellar-service/package.json
+++ b/apps/stellar-service/package.json
@@ -25,6 +25,7 @@
     }
   },
   "dependencies": {
+    "@qyou/config": "*",
     "@qyou/types": "*",
     "@stellar/stellar-sdk": "^14.3.3",
     "express": "^5.1.0"

--- a/apps/stellar-service/src/index.ts
+++ b/apps/stellar-service/src/index.ts
@@ -2,6 +2,7 @@ import express from "express";
 import type { Request, Response } from "express";
 import { Horizon } from "@stellar/stellar-sdk";
 import type { RewardAccountReadinessResult } from "@qyou/types";
+import { getAuthBaselineReport, loadNodeServiceConfig, loadStellarAuthConfig } from "@qyou/config";
 import { link, unlink, rotate, initiateRecovery, confirmRecovery, checkRewardReadiness } from "./wallet-link.js";
 import { issueChallenge, verifyChallenge } from "./challenge-verify.js";
 import type {
@@ -26,11 +27,22 @@ type StellarServiceInfo = {
   rpcUrl: string;
 };
 
-const port = Number(process.env.PORT ?? 4100);
-const network = process.env.STELLAR_NETWORK ?? "testnet";
-const rpcUrl = process.env.STELLAR_RPC_URL ?? "https://soroban-testnet.stellar.org";
-const horizonUrl = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
-const horizonServer = new Horizon.Server(horizonUrl);
+const serviceConfig = loadNodeServiceConfig({ defaultPort: 4100, serviceName: "stellar-service" });
+const stellarConfig = loadStellarAuthConfig();
+
+// AUTH-102/103/104: baseline check for shared auth config across workspaces.
+const baseline = getAuthBaselineReport();
+for (const warning of baseline.warnings) {
+  console.warn(JSON.stringify({ level: "warn", event: "auth.baseline.warning", warning, ts: new Date().toISOString() }));
+}
+if (!baseline.ok) {
+  for (const error of baseline.errors) {
+    console.error(JSON.stringify({ level: "error", event: "auth.baseline.error", error, ts: new Date().toISOString() }));
+  }
+  throw new Error("Shared auth baseline validation failed.");
+}
+
+const horizonServer = new Horizon.Server(stellarConfig.horizonUrl);
 
 const app = express();
 app.use(express.json());
@@ -70,8 +82,8 @@ app.get("/api/v1/stellar/info", async (_req, res) => {
     const latestLedger = await horizonServer.ledgers().order("desc").limit(1).call();
     res.json({
       latestLedgerSequence: latestLedger.records[0]?.sequence ?? null,
-      network,
-      rpcUrl
+      network: stellarConfig.network,
+      rpcUrl: stellarConfig.rpcUrl
     });
   } catch (err) {
     logError("stellar.info.failed", { error: String(err) });
@@ -413,6 +425,11 @@ app.post("/api/v1/stellar/challenge/verify", (request: Request, response: Respon
   response.status(statusMap[result.code] ?? 500).json(result);
 });
 
-app.listen(port, () => {
-  logInfo("stellar_service.started", { port, network, horizonUrl, rpcUrl });
+app.listen(serviceConfig.port, () => {
+  logInfo("stellar_service.started", {
+    port: serviceConfig.port,
+    network: stellarConfig.network,
+    horizonUrl: stellarConfig.horizonUrl,
+    rpcUrl: stellarConfig.rpcUrl
+  });
 });

--- a/apps/web/src/lib/auth-api.ts
+++ b/apps/web/src/lib/auth-api.ts
@@ -18,9 +18,6 @@ export type LoginInput = {
 export type LoginResult =
   | { ok: true; accountId: string; email: string; tokens: { accessToken: string; expiresAt: string; refreshToken: string } }
   | { ok: false; code: string; message: string };
-export type VerifyResult =
-  | { ok: true; accountId: string; status: string; verifiedAt: string }
-  | { ok: false; code: string; message: string };
 
 export type ResetRequestResult = { ok: true } | { ok: false; code: string; message: string };
 export type ResetConfirmResult = { ok: true } | { ok: false; code: string; message: string };

--- a/docs/auth-stellar-wallet-unlink-recovery.md
+++ b/docs/auth-stellar-wallet-unlink-recovery.md
@@ -1,0 +1,126 @@
+# AUTH-091 — Wallet Unlink, Rotation, and Account Recovery Flow
+
+## Overview
+
+This document captures the target flow, boundaries, and failure states for the Stellar wallet unlink, rotation, and recovery lifecycle.
+
+Scope: the Stellar linking surface owned by `@qyou/stellar-service` and the shared contracts in `@qyou/types`.
+
+Backlog-ID: AUTH-091  
+Backlog-Slug: auth-091-st-design-the-unlink-rotation-and-account-recovery-flow
+
+## High-level principles
+
+- Treat wallet linkage as identity infrastructure (high-risk, audit-friendly), not a convenience feature.
+- Make every mutation explicit: `link`, `unlink`, `rotate`, `initiateRecovery`, `confirmRecovery`.
+- Keep recovery tokens short-lived, single-use, and scoped to `(accountId, token)`.
+- Keep failure states stable and typed (clients can reason about UX without guessing).
+
+## Service boundary
+
+- `@qyou/types` owns the request/response shapes (DTOs + error codes).
+- `@qyou/stellar-service` owns the state machine and the mutation endpoints.
+- `@qyou/api` should treat Stellar wallet lifecycle as a downstream dependency (no duplicate state).
+
+## State model
+
+`WalletLinkRecord` (source of truth shape): `packages/types/src/index.ts`
+
+```ts
+type WalletLinkRecord = {
+  accountId: string;
+  walletAddress: string;
+  linkedAt: string;
+  rotatedAt?: string;
+  recoveryToken?: string;
+  recoveryExpiresAt?: number;
+};
+```
+
+### States
+
+- `UNLINKED`: no record exists for `accountId`
+- `LINKED`: record exists and `recoveryToken` is unset
+- `RECOVERY_IN_PROGRESS`: record exists and `recoveryToken` + `recoveryExpiresAt` are set and not expired
+
+## Endpoints (route contract)
+
+Owned by `apps/stellar-service/src/index.ts`.
+
+### `POST /api/v1/stellar/wallet/unlink`
+
+Request body:
+```json
+{ "accountId": "acc_..." }
+```
+
+Response:
+- `200` → `{ "ok": true }`
+- `404` → `{ "ok": false, "code": "NOT_LINKED", "message": "..." }`
+
+Security + failure notes:
+- Idempotency is acceptable (`NOT_LINKED` can be treated as a no-op by callers).
+- When unlinking, clear any in-flight recovery state and emit an audit event with the prior address (server-side).
+
+### `POST /api/v1/stellar/wallet/rotate`
+
+Request body:
+```json
+{ "accountId": "acc_...", "newWalletAddress": "G..." }
+```
+
+Response:
+- `200` → `{ "ok": true, "accountId": "...", "walletAddress": "G...", "rotatedAt": "..." }`
+- `404` → `{ "ok": false, "code": "NOT_LINKED", "message": "..." }`
+
+Security + failure notes:
+- Rotation must be serialized per `accountId` to avoid double-rotation races.
+- Rotation should be rejected while `RECOVERY_IN_PROGRESS` (or require completing/canceling recovery first).
+
+### `POST /api/v1/stellar/wallet/recovery/initiate`
+
+Request body:
+```json
+{ "accountId": "acc_..." }
+```
+
+Response:
+- `200` → `{ "ok": true, "recoveryToken": "<uuid>", "expiresAt": "<iso>" }`
+- `404` → `{ "ok": false, "code": "NOT_LINKED", "message": "..." }`
+
+Security + failure notes:
+- Initiation is rate-limited per `accountId` to prevent token-spam.
+- Issuing a new token should invalidate any previous token for the same `accountId`.
+- Token must be opaque (UUID) and short-lived.
+
+### `POST /api/v1/stellar/wallet/recovery/confirm`
+
+Request body:
+```json
+{
+  "accountId": "acc_...",
+  "recoveryToken": "<uuid>",
+  "newWalletAddress": "G..."
+}
+```
+
+Response:
+- `200` → `{ "ok": true, "accountId": "...", "walletAddress": "G..." }`
+- `401` → `{ "ok": false, "code": "INVALID_RECOVERY_TOKEN", "message": "..." }`
+
+Security + failure notes:
+- Confirm must be single-use and atomic (consume token + set new address).
+- Confirm must validate `(accountId, token)` binding and expiry.
+- Confirm should emit an audit event including prior + new address, and whether recovery replaced an existing link.
+
+## UX recommendations (client-facing)
+
+- Unlink: require explicit confirmation (“This will disconnect rewards.”).
+- Rotate: show current address and require re-entry or signature challenge for high assurance.
+- Recovery: present as a last resort; clearly communicate expiry and single-use behavior.
+
+## Verification notes
+
+- Start the stellar service and exercise flows with `curl` against the endpoints above.
+- Prefer validating behavior via typed results (`WalletUnlinkResult`, `WalletRotateResult`, `WalletRecovery*Result`) rather than relying on log output alone.
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packages/*"
   ],
   "scripts": {
+    "auth:baseline": "npm run build --workspace @qyou/config && npm run auth:baseline --workspace @qyou/config",
     "build": "npm run build --workspace @qyou/types && npm run build --workspace @qyou/config && npm run build --workspace @qyou/api && npm run build --workspace @qyou/stellar-service && npm run build --workspace @qyou/web",
     "dev": "concurrently \"npm run dev:api\" \"npm run dev:web\" \"npm run dev:mobile\" \"npm run dev:stellar-service\"",
     "dev:api": "npm run dev --workspace @qyou/api",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "tsc -p tsconfig.json --noEmit",
+    "auth:baseline": "node dist/auth-baseline-cli.js",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/config/src/auth-baseline-cli.ts
+++ b/packages/config/src/auth-baseline-cli.ts
@@ -1,0 +1,38 @@
+import { getAuthBaselineReport } from "./index.js";
+
+function printSection(title: string, lines: string[]): void {
+  if (lines.length === 0) return;
+  // eslint-disable-next-line no-console
+  console.log(`\n${title}`);
+  for (const line of lines) {
+    // eslint-disable-next-line no-console
+    console.log(`- ${line}`);
+  }
+}
+
+export function main(): void {
+  const report = getAuthBaselineReport();
+
+  // eslint-disable-next-line no-console
+  console.log("AUTH baseline report");
+  // eslint-disable-next-line no-console
+  console.log(`nodeEnv: ${report.nodeEnv}`);
+  // eslint-disable-next-line no-console
+  console.log(
+    `auth: accessTtl=${report.auth.accessTokenTtlSeconds}s refreshTtl=${report.auth.refreshTokenTtlSeconds}s corsOrigin=${report.auth.corsOrigin}`
+  );
+  // eslint-disable-next-line no-console
+  console.log(
+    `stellar: network=${report.stellar.network} horizon=${report.stellar.horizonUrl} rpc=${report.stellar.rpcUrl}`
+  );
+
+  printSection("Warnings", report.warnings);
+  printSection("Errors", report.errors);
+
+  if (!report.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main();
+

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2,6 +2,32 @@ import { config as loadDotenv } from "dotenv";
 
 loadDotenv();
 
+function parseNumberEnv(
+  name: string,
+  fallback: number,
+  options?: { integer?: boolean; min?: number }
+): { value: number; usedFallback: boolean } {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return { value: fallback, usedFallback: true };
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid ${name} value.`);
+  }
+
+  if (options?.integer && !Number.isInteger(parsed)) {
+    throw new Error(`${name} must be an integer.`);
+  }
+
+  if (options?.min !== undefined && parsed < options.min) {
+    throw new Error(`${name} must be >= ${options.min}.`);
+  }
+
+  return { value: parsed, usedFallback: false };
+}
+
 type NodeServiceConfigOptions = {
   defaultPort: number;
   serviceName: string;
@@ -63,10 +89,13 @@ export function loadAuthConfig(): AuthConfig {
     throw new Error("JWT_SECRET must be set in production.");
   }
 
+  const accessTtl = parseNumberEnv("ACCESS_TOKEN_TTL_SECONDS", 900, { integer: true, min: 1 });
+  const refreshTtl = parseNumberEnv("REFRESH_TOKEN_TTL_SECONDS", 604800, { integer: true, min: 1 });
+
   return {
     jwtSecret: jwtSecret ?? "dev-secret-change-in-production",
-    accessTokenTtlSeconds: Number(process.env.ACCESS_TOKEN_TTL_SECONDS ?? 900),
-    refreshTokenTtlSeconds: Number(process.env.REFRESH_TOKEN_TTL_SECONDS ?? 604800),
+    accessTokenTtlSeconds: accessTtl.value,
+    refreshTokenTtlSeconds: refreshTtl.value,
     corsOrigin: process.env.CORS_ORIGIN ?? "http://localhost:3000"
   };
 }
@@ -75,7 +104,11 @@ export function loadAuthConfig(): AuthConfig {
  * Load Stellar-specific auth config from environment variables.
  */
 export function loadStellarAuthConfig(): StellarAuthConfig {
-  const network = (process.env.STELLAR_NETWORK ?? "testnet") as "testnet" | "mainnet";
+  const rawNetwork = process.env.STELLAR_NETWORK ?? "testnet";
+  if (rawNetwork !== "testnet" && rawNetwork !== "mainnet") {
+    throw new Error("STELLAR_NETWORK must be 'testnet' or 'mainnet'.");
+  }
+  const network = rawNetwork;
 
   const defaults = {
     testnet: {
@@ -92,5 +125,89 @@ export function loadStellarAuthConfig(): StellarAuthConfig {
     network,
     horizonUrl: process.env.STELLAR_HORIZON_URL ?? defaults[network].horizonUrl,
     rpcUrl: process.env.STELLAR_RPC_URL ?? defaults[network].rpcUrl
+  };
+}
+
+export type AuthBaselineReport = {
+  ok: boolean;
+  nodeEnv: string;
+  warnings: string[];
+  errors: string[];
+  auth: AuthConfig;
+  stellar: StellarAuthConfig;
+};
+
+/**
+ * AUTH-102/103/104: Shared auth config & environment baseline
+ * - Wires env parsing/validation in one place
+ * - Emits a high-signal report (warnings vs errors)
+ * - Safe for startup-time checks (does not throw)
+ */
+export function getAuthBaselineReport(): AuthBaselineReport {
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  const nodeEnv = process.env.NODE_ENV ?? "development";
+
+  let auth: AuthConfig;
+  let stellar: StellarAuthConfig;
+
+  try {
+    auth = loadAuthConfig();
+  } catch (err) {
+    errors.push(String(err instanceof Error ? err.message : err));
+    auth = {
+      jwtSecret: "dev-secret-change-in-production",
+      accessTokenTtlSeconds: 900,
+      refreshTokenTtlSeconds: 604800,
+      corsOrigin: process.env.CORS_ORIGIN ?? "http://localhost:3000"
+    };
+  }
+
+  try {
+    stellar = loadStellarAuthConfig();
+  } catch (err) {
+    errors.push(String(err instanceof Error ? err.message : err));
+    stellar = {
+      network: "testnet",
+      horizonUrl: process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org",
+      rpcUrl: process.env.STELLAR_RPC_URL ?? "https://soroban-testnet.stellar.org"
+    };
+  }
+
+  if (nodeEnv !== "production" && !process.env.JWT_SECRET) {
+    warnings.push("JWT_SECRET is not set; using development default.");
+  }
+
+  if (!process.env.ACCESS_TOKEN_TTL_SECONDS) {
+    warnings.push("ACCESS_TOKEN_TTL_SECONDS is not set; using default (900 seconds).");
+  }
+
+  if (!process.env.REFRESH_TOKEN_TTL_SECONDS) {
+    warnings.push("REFRESH_TOKEN_TTL_SECONDS is not set; using default (604800 seconds).");
+  }
+
+  if (!process.env.CORS_ORIGIN) {
+    warnings.push("CORS_ORIGIN is not set; using default (http://localhost:3000).");
+  }
+
+  if (!process.env.STELLAR_NETWORK) {
+    warnings.push("STELLAR_NETWORK is not set; using default (testnet).");
+  }
+
+  if (!process.env.STELLAR_HORIZON_URL) {
+    warnings.push("STELLAR_HORIZON_URL is not set; using network default.");
+  }
+
+  if (!process.env.STELLAR_RPC_URL) {
+    warnings.push("STELLAR_RPC_URL is not set; using network default.");
+  }
+
+  return {
+    ok: errors.length === 0,
+    nodeEnv,
+    warnings,
+    errors,
+    auth,
+    stellar
   };
 }


### PR DESCRIPTION
Implements and wires a shared auth config/environment baseline across workspaces.

- Adds `getAuthBaselineReport()` + stricter env parsing/validation in `@qyou/config`
- Adds `npm run auth:baseline` to exercise the baseline quickly
- Wires shared auth config into `@qyou/api` (JWT secret + TTLs)
- Wires shared stellar auth config into `@qyou/stellar-service`
- Adds wallet unlink/rotation/recovery design doc (AUTH-091)

Closes Qyoue/Qyou#420
Closes Qyoue/Qyou#421
Closes Qyoue/Qyou#422
Closes Qyoue/Qyou#409