### PR TITLE
feat(stellar): signed challenge hardening + verification docs

### DIFF
--- a/apps/stellar-service/package.json
+++ b/apps/stellar-service/package.json
@@ -7,7 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsx watch src/index.ts",
     "lint": "tsc -p tsconfig.json --noEmit",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --testPathPattern='(challenge-verify|reward-account-readiness)' && node --import tsx/esm --test src/wallet-link.test.ts",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --watchman=false --testPathPattern='(challenge-verify|reward-account-readiness|wallet-link)'",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "jest": {

--- a/apps/stellar-service/src/challenge-verify.test.ts
+++ b/apps/stellar-service/src/challenge-verify.test.ts
@@ -93,6 +93,27 @@ describe("issueChallenge — validation", () => {
 });
 
 // ---------------------------------------------------------------------------
+// verifyChallenge — rate-limit
+// ---------------------------------------------------------------------------
+
+describe("verifyChallenge — rate-limit", () => {
+  it("returns RATE_LIMITED after exceeding verify attempts per address", () => {
+    const issued = issueChallenge({ walletAddress: VALID_ADDRESS });
+    if (!issued.ok) throw new Error("unreachable");
+
+    // Intentionally use bad signatures; rate-limit should still trip.
+    for (let i = 0; i < 10; i++) {
+      verifyChallenge({ challengeId: issued.challengeId, walletAddress: VALID_ADDRESS, signature: "bad" });
+    }
+
+    const limited = verifyChallenge({ challengeId: issued.challengeId, walletAddress: VALID_ADDRESS, signature: "bad" });
+    expect(limited.ok).toBe(false);
+    if (limited.ok) throw new Error("unreachable");
+    expect(limited.code).toBe("RATE_LIMITED");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // verifyChallenge — happy path
 // ---------------------------------------------------------------------------
 
@@ -195,6 +216,9 @@ describe("verifyChallenge — expiry", () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("unreachable");
     expect(result.code).toBe("CHALLENGE_EXPIRED");
+
+    // Expired challenges are cleaned up.
+    expect(challengeStore.has(issued.challengeId)).toBe(false);
   });
 });
 

--- a/apps/stellar-service/src/challenge-verify.ts
+++ b/apps/stellar-service/src/challenge-verify.ts
@@ -43,7 +43,8 @@ export const CHALLENGE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 export const STORE_MAX_SIZE = 10_000;
 
 const RATE_WINDOW_MS = 60_000;
-const RATE_MAX = 5;
+const RATE_MAX_ISSUE = 5;
+const RATE_MAX_VERIFY = 10;
 
 // ---------------------------------------------------------------------------
 // Stores
@@ -53,6 +54,7 @@ const RATE_MAX = 5;
 export const challengeStore = new Map<string, ChallengeRecord>();
 
 const rateBuckets = new Map<string, { count: number; windowStart: number }>();
+const verifyRateBuckets = new Map<string, { count: number; windowStart: number }>();
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -79,7 +81,18 @@ function isRateLimited(key: string): boolean {
     return false;
   }
   bucket.count += 1;
-  return bucket.count > RATE_MAX;
+  return bucket.count > RATE_MAX_ISSUE;
+}
+
+function isVerifyRateLimited(key: string): boolean {
+  const now = Date.now();
+  const bucket = verifyRateBuckets.get(key);
+  if (!bucket || now - bucket.windowStart > RATE_WINDOW_MS) {
+    verifyRateBuckets.set(key, { count: 1, windowStart: now });
+    return false;
+  }
+  bucket.count += 1;
+  return bucket.count > RATE_MAX_VERIFY;
 }
 
 function evictIfFull(): void {
@@ -93,6 +106,7 @@ function evictIfFull(): void {
 export function clearChallengeStore(): void {
   challengeStore.clear();
   rateBuckets.clear();
+  verifyRateBuckets.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -193,6 +207,12 @@ export function verifyChallenge(input: ChallengeVerifyInput): ChallengeVerifyRes
     return fail("VALIDATION_ERROR", "signature is required.");
   }
 
+  // AUTH-083: per-address rate-limit for verify as well (defense-in-depth)
+  if (isVerifyRateLimited(walletAddress)) {
+    log("warn", "CHALLENGE_VERIFY_ERROR", { challengeId, walletAddress, reason: "rate_limited", latency_ms: Date.now() - start });
+    return fail("RATE_LIMITED", "Too many verification attempts. Try again later.");
+  }
+
   // --- Look up challenge ---
   const record = challengeStore.get(challengeId);
   if (!record) {
@@ -202,6 +222,8 @@ export function verifyChallenge(input: ChallengeVerifyInput): ChallengeVerifyRes
 
   // --- Expiry check ---
   if (Date.now() > record.expiresAt) {
+    // AUTH-083: cleanup expired challenges to prevent store drift
+    challengeStore.delete(challengeId);
     log("warn", "CHALLENGE_VERIFY_ERROR", { challengeId, reason: "expired", latency_ms: Date.now() - start });
     return fail("CHALLENGE_EXPIRED", "Challenge has expired. Please request a new one.");
   }

--- a/docs/auth-stellar-signed-challenge-verification.md
+++ b/docs/auth-stellar-signed-challenge-verification.md
@@ -1,0 +1,52 @@
+# AUTH-083..085 — Signed Challenge Verification (Hardening, Instrumentation, Verification)
+
+This document describes how to exercise and verify the signed challenge verification flow in `@qyou/stellar-service`.
+
+Backlog-IDs:
+- AUTH-083 (Harden)
+- AUTH-084 (Instrument)
+- AUTH-085 (Verify)
+- AUTH-080 (Verify wallet-link initiation contract)
+
+## What to run
+
+From the repo root:
+
+```bash
+npm test --workspace @qyou/stellar-service
+```
+
+This runs:
+- `src/challenge-verify.test.ts` (signed challenge issue + verify flow)
+- `src/wallet-link.test.ts` and `src/wallet-link-completion.test.ts` (wallet link initiation + completion contracts)
+
+## Manual smoke test (optional)
+
+1) Start the service:
+
+```bash
+npm run dev --workspace @qyou/stellar-service
+```
+
+2) Issue a challenge:
+
+```bash
+curl -sS -X POST http://localhost:4100/api/v1/stellar/challenge/issue \
+  -H 'Content-Type: application/json' \
+  -d '{ "walletAddress": "G..." }'
+```
+
+3) Sign the returned `nonce` with the Stellar private key for that public key (client-side), base64-encode the signature, then verify:
+
+```bash
+curl -sS -X POST http://localhost:4100/api/v1/stellar/challenge/verify \
+  -H 'Content-Type: application/json' \
+  -d '{ "challengeId": "<uuid>", "walletAddress": "G...", "signature": "<base64>" }'
+```
+
+## Operational notes
+
+- Challenges are short-lived and single-use; replay attempts return `CHALLENGE_ALREADY_USED`.
+- Issue and verify are rate-limited per wallet address to reduce abuse surface.
+- Log events are structured JSON and include `challengeId` and `walletAddress` for high-signal debugging.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,8 +44,7 @@
         "@types/jest": "^29.5.14",
         "@types/react": "~19.1.10",
         "jest": "^29.7.0",
-        "ts-jest": "^29.4.0",
-        "typescript": "^5.9.3"
+        "ts-jest": "^29.4.0"
       }
     },
     "apps/stellar-service": {


### PR DESCRIPTION
Hardens and documents the Stellar signed-challenge verification flow.

- Adds per-address verify rate-limiting + expired-challenge cleanup
- Adds regression tests for verify rate limiting + expiry cleanup
- Fixes `@qyou/stellar-service` test script to run all tests under Jest (and disables watchman)
- Adds a short verification doc with rerun + manual curl smoke steps

Closes Qyoue/Qyou#401
Closes Qyoue/Qyou#402
Closes Qyoue/Qyou#403
Closes Qyoue/Qyou#398