### PR TITLE
feat(stellar): wallet-link completion docs + hardening

### DIFF
--- a/apps/stellar-service/package.json
+++ b/apps/stellar-service/package.json
@@ -7,7 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsx watch src/index.ts",
     "lint": "tsc -p tsconfig.json --noEmit",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --testPathPattern='(challenge-verify|reward-account-readiness)' && node --import tsx/esm --test src/wallet-link.test.ts",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --watchman=false --testPathPattern='(challenge-verify|reward-account-readiness|wallet-link)'",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "jest": {

--- a/apps/stellar-service/src/wallet-link-completion.test.ts
+++ b/apps/stellar-service/src/wallet-link-completion.test.ts
@@ -82,6 +82,32 @@ describe("wallet-link completion flow (AUTH-089)", () => {
     if (after.ready) expect(after.walletAddress).toBe(ADDR_B);
   });
 
+  it("link → initiate recovery → rotate invalidates recovery token", () => {
+    link({ accountId: "flow-rotate-1", walletAddress: ADDR_A });
+    const init = initiateRecovery({ accountId: "flow-rotate-1" });
+    expect(init.ok).toBe(true);
+    if (!init.ok) throw new Error("unreachable");
+
+    const rotated = rotate({ accountId: "flow-rotate-1", newWalletAddress: ADDR_B });
+    expect(rotated.ok).toBe(true);
+
+    // Token is invalidated after rotation.
+    const confirm = confirmRecovery({
+      accountId: "flow-rotate-1",
+      recoveryToken: init.recoveryToken,
+      newWalletAddress: ADDR_A,
+    });
+    expect(confirm.ok).toBe(false);
+    if (!confirm.ok) expect(confirm.code).toBe("INVALID_RECOVERY_TOKEN");
+
+    // Store reflects the rotation and no in-progress recovery.
+    const record = walletStore.get("flow-rotate-1");
+    expect(record?.walletAddress).toBe(ADDR_B);
+    expect(record?.recoveryToken).toBeUndefined();
+    expect(record?.recoveryExpiresAt).toBeUndefined();
+    expect(recoveryStore.has(init.recoveryToken)).toBe(false);
+  });
+
   it("link → unlink → readiness returns NO_WALLET_LINKED", () => {
     link({ accountId: "flow-4", walletAddress: ADDR_A });
     unlink({ accountId: "flow-4" });

--- a/apps/stellar-service/src/wallet-link.ts
+++ b/apps/stellar-service/src/wallet-link.ts
@@ -295,6 +295,15 @@ export function rotate(input: WalletRotateInput): WalletRotateResult {
   rotateInFlight.add(accountId);
   try {
     const existing = walletStore.get(accountId)!;
+    // AUTH-088: rotation invalidates any outstanding recovery tokens to prevent stale-token reuse.
+    let recoveryTokensInvalidated = 0;
+    for (const [token, entry] of recoveryStore) {
+      if (entry.accountId === accountId) {
+        recoveryStore.delete(token);
+        recoveryTokensInvalidated++;
+      }
+    }
+
     // AUTH-094: capture previous address for audit trail
     const previousWalletAddress = existing.walletAddress;
     const newWalletAddress = input.newWalletAddress.trim();
@@ -303,6 +312,8 @@ export function rotate(input: WalletRotateInput): WalletRotateResult {
       ...existing,
       walletAddress: newWalletAddress,
       rotatedAt,
+      recoveryToken: undefined,
+      recoveryExpiresAt: undefined,
     };
     walletStore.set(accountId, updated);
     // AUTH-094: log both old and new addresses for audit trail
@@ -311,6 +322,7 @@ export function rotate(input: WalletRotateInput): WalletRotateResult {
       previousWalletAddress,
       newWalletAddress,
       rotatedAt,
+      recoveryTokensInvalidated,
       latency_ms: Date.now() - start,
     });
     return { ok: true, accountId, walletAddress: newWalletAddress, rotatedAt };

--- a/docs/auth-stellar-wallet-link-completion.md
+++ b/docs/auth-stellar-wallet-link-completion.md
@@ -1,0 +1,80 @@
+# AUTH-086..090 — Wallet-Link Completion & Account Binding (Design, Implementation, Hardening, Verification)
+
+This document describes the wallet-link completion and account binding flow implemented in `@qyou/stellar-service`, with verification notes for contributors.
+
+Backlog-IDs:
+- AUTH-086 (Design)
+- AUTH-087 (Implement)
+- AUTH-088 (Harden)
+- AUTH-090 (Verify)
+
+## Scope
+
+- Service: `apps/stellar-service`
+- Contracts: `packages/types` (`WalletLink*` DTOs, error codes)
+- Non-goals: persistence/DB adapters (current stores are in-memory by design)
+
+## Why this exists
+
+The completion flow ensures we never end up in a partially-bound state where:
+- an account appears linked but cannot reliably receive rewards, or
+- a stale recovery token can mutate identity after a safe rotation.
+
+## State model
+
+Primary record: `WalletLinkRecord` keyed by `accountId`.
+
+States:
+- `UNLINKED`: no record for account
+- `LINKED`: record exists
+- `RECOVERY_IN_PROGRESS`: record exists + recovery token is active (bounded TTL)
+
+## Core flows
+
+### 1) Link (bind wallet)
+
+Call: `link({ accountId, walletAddress })`
+
+Guarantees:
+- cannot overwrite an existing link (`ALREADY_LINKED`)
+- records `linkedAt` (audit-friendly)
+- rate-limited per `accountId`
+
+### 2) Rotate (change wallet)
+
+Call: `rotate({ accountId, newWalletAddress })`
+
+Guarantees:
+- atomic update to the wallet address
+- concurrent rotate requests are prevented per `accountId`
+- invalidates any outstanding recovery tokens for the account (hardening)
+
+### 3) Recovery (regain control)
+
+Calls:
+- `initiateRecovery({ accountId })` → issues a short-lived opaque token
+- `confirmRecovery({ accountId, recoveryToken, newWalletAddress })` → consumes token and writes the new address
+
+Guarantees:
+- tokens are single-use, time-boxed, and account-bound
+- confirm consumes the token even when the account mismatch / expiry logic triggers
+
+### 4) Readiness check
+
+Call: `checkRewardReadiness(accountId)`
+
+Guarantees:
+- returns `RECOVERY_IN_PROGRESS` while a valid recovery token is active to prevent payout ambiguity
+
+## Verification (tests)
+
+Run the Stellar service tests:
+
+```bash
+npm test --workspace @qyou/stellar-service
+```
+
+Key coverage:
+- `apps/stellar-service/src/wallet-link-completion.test.ts` — completion lifecycle + partial binding prevention
+- `apps/stellar-service/src/wallet-link.test.ts` — guardrails, rate limits, audit trail, recovery behavior
+


### PR DESCRIPTION
Adds design/verification documentation and hardens the wallet-link completion lifecycle.

- Adds AUTH-086..090 doc describing completion/account-binding flows and how to verify
- Hardens rotation to invalidate any outstanding recovery tokens (prevents stale-token reuse)
- Adds regression test ensuring recovery tokens are invalid after rotate
- Fixes `@qyou/stellar-service` test script to run all tests under Jest and disables watchman

Closes Qyoue/Qyou#404
Closes Qyoue/Qyou#405
Closes Qyoue/Qyou#406
Closes Qyoue/Qyou#408