### PR TITLE
AUTH-113–116: auth observability ops — monitor, exercise, docs, abuse controls

### DIFF
--- a/docs/auth-observability.md
+++ b/docs/auth-observability.md
@@ -1,48 +1,135 @@
-# AUTH-111/112 — Auth Observability & Audit Baseline
+# AUTH-111–116 — Auth Observability, Audit & Abuse Controls
 
-This document defines the baseline conventions for auth observability (logs/audit signals) across workspaces.
-
-Backlog-IDs:
-- AUTH-111 (define)
-- AUTH-112 (wire)
+Covers AUTH-111 through AUTH-116.
 
 ## Goals
 
-- Make auth flows debuggable in hackathon environments without adding heavy dependencies.
+- Make auth flows debuggable in hackathon environments without heavy dependencies.
 - Keep events consistent across workspaces (API + Stellar service).
-- Avoid copy/paste logger implementations drifting over time.
+- Block obvious abuse at the auth layer without external services.
 
-## Baseline: structured JSON logs
+---
 
-All auth-related modules should emit JSON logs with these fields:
+## 1. Structured logging
 
-- `ts`: ISO-8601 timestamp
-- `level`: `info` | `warn` | `error`
-- `event`: stable event name (e.g. `LOGIN_OK`, `WALLET_LINK_ERROR`)
-- `service`: high-level service name (`api`, `stellar-service`)
-- `component`: module name (e.g. `auth.login`)
-- plus event-specific fields (`accountId`, `walletAddress`, `latency_ms`, `reason`, etc.)
-
-## Implementation (shared helper)
-
-Use the shared logger helper from `@qyou/config`:
+All auth modules must emit JSON logs via the shared helper:
 
 ```ts
 import { createStructuredLogger } from "@qyou/config";
 
 const log = createStructuredLogger({ service: "api", component: "auth.login" });
 log("info", "LOGIN_OK", { accountId, latency_ms });
+log("warn", "RATE_LIMITED", { ip, operation: "login" });
+log("error", "LOGIN_FAIL", { reason: "invalid credentials" });
 ```
 
-This keeps the log shape consistent and prevents logger drift across workspaces.
+Required fields on every entry: `ts` (ISO-8601), `level`, `event`, `service`.  
+Optional but encouraged: `component`, `accountId`, `walletAddress`, `latency_ms`, `reason`, `ip`.
 
-## Monitoring
+**Common pitfall**: do not define a local `function log(...)` — the audit script flags it as drift.
 
-Run:
+---
+
+## 2. Abuse controls
+
+The `checkAbuse` helper from `@qyou/config` provides in-process rate limiting:
+
+```ts
+import { checkAbuse } from "@qyou/config";
+
+const result = checkAbuse({ operation: "login", ip: req.ip, accountId });
+if (!result.allowed) {
+  // result.code === "RATE_LIMITED", result.retryAfterMs available
+  return res.status(429).json({ error: result.code });
+}
+```
+
+Default limits (per key, per window):
+
+| Operation         | Max attempts | Window   |
+|-------------------|-------------|----------|
+| `login`           | 10          | 60 s     |
+| `register`        | 5           | 60 s     |
+| `password-reset`  | 3           | 5 min    |
+| `challenge-verify`| 10          | 60 s     |
+
+Buckets are keyed by `accountId` when available, falling back to `ip`.  
+For production, swap the in-memory store with Redis by replacing the internal `buckets` Map.
+
+### Device trust
+
+The `DeviceTrustRecord` type (from `@qyou/types`) defines the contract for
+per-device trust state. Persist it alongside the account record and gate
+sensitive operations on `trusted: false` with a step-up challenge.
+
+---
+
+## 3. Scripts
+
+### Monitor (AUTH-113)
+
+Surfaces high-signal events and separates warnings from real failures:
+
+```bash
+node scripts/auth-observability-monitor.mjs
+```
+
+- **Warnings** (exit 0): missing optional env vars with safe defaults.
+- **Errors** (exit 1): ad-hoc loggers detected, required env missing in production, build failures.
+
+### Exercise (AUTH-114)
+
+Runs fixture scenarios against the logger and abuse-control baseline:
+
+```bash
+npm run build  # types + config must be built first
+node scripts/auth-observability-exercise.mjs
+```
+
+Scenarios covered: logger shape, error routing, rate-limit enforcement, bucket isolation by operation and account.
+
+### Existing audit script (AUTH-111/112)
 
 ```bash
 npm run auth:observability
 ```
 
-This checks for common drift signals (e.g., ad-hoc `function log(...)` definitions) and ensures the affected workspaces build/typecheck.
+Checks for logger drift (ad-hoc `function log(...)`) in auth source files.
 
+---
+
+## 4. Prerequisites and secrets
+
+| Variable                   | Required in prod | Default (dev)                          |
+|----------------------------|-----------------|----------------------------------------|
+| `JWT_SECRET`               | ✓               | `dev-secret-change-in-production`      |
+| `ACCESS_TOKEN_TTL_SECONDS` |                 | `900`                                  |
+| `REFRESH_TOKEN_TTL_SECONDS`|                 | `604800`                               |
+| `CORS_ORIGIN`              |                 | `http://localhost:3000`                |
+| `STELLAR_NETWORK`          |                 | `testnet`                              |
+| `STELLAR_HORIZON_URL`      |                 | network default                        |
+| `STELLAR_RPC_URL`          |                 | network default                        |
+
+Copy the relevant `.env.example` files and fill in production values.  
+Never commit real secrets.
+
+---
+
+## 5. Contributor quick-start
+
+```bash
+# 1. Build shared packages
+npm run build --workspace @qyou/types
+npm run build --workspace @qyou/config
+
+# 2. Run the monitor (warnings are normal in dev)
+node scripts/auth-observability-monitor.mjs
+
+# 3. Exercise the baseline
+node scripts/auth-observability-exercise.mjs
+
+# 4. Full baseline report
+npm run auth:baseline
+```
+
+A new contributor should be able to run these four commands on a fresh clone with no extra setup beyond `npm install`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "name": "@qyou/api",
       "version": "0.1.0",
       "dependencies": {
+        "@qyou/config": "*",
         "@qyou/types": "*",
         "cors": "^2.8.5",
         "express": "^5.1.0"
@@ -51,6 +52,7 @@
       "name": "@qyou/stellar-service",
       "version": "0.1.0",
       "dependencies": {
+        "@qyou/config": "*",
         "@qyou/types": "*",
         "@stellar/stellar-sdk": "^14.3.3",
         "express": "^5.1.0"
@@ -68,6 +70,7 @@
       "name": "@qyou/web",
       "version": "0.1.0",
       "dependencies": {
+        "@qyou/types": "*",
         "next": "16.1.4",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -12308,6 +12311,7 @@
       "name": "@qyou/config",
       "version": "0.1.0",
       "dependencies": {
+        "@qyou/types": "^0.1.0",
         "dotenv": "^17.2.3"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   ],
   "scripts": {
     "auth:baseline": "npm run build --workspace @qyou/config && npm run auth:baseline --workspace @qyou/config",
+    "auth:observability": "node scripts/auth-observability-audit.mjs",
+    "auth:monitor": "node scripts/auth-observability-monitor.mjs",
+    "auth:exercise": "npm run build --workspace @qyou/types && npm run build --workspace @qyou/config && node scripts/auth-observability-exercise.mjs",
     "build": "npm run build --workspace @qyou/types && npm run build --workspace @qyou/config && npm run build --workspace @qyou/api && npm run build --workspace @qyou/stellar-service && npm run build --workspace @qyou/web",
     "dev": "concurrently \"npm run dev:api\" \"npm run dev:web\" \"npm run dev:mobile\" \"npm run dev:stellar-service\"",
     "dev:api": "npm run dev --workspace @qyou/api",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@qyou/types": "^0.1.0",
     "dotenv": "^17.2.3"
   },
   "devDependencies": {

--- a/packages/config/src/abuse.ts
+++ b/packages/config/src/abuse.ts
@@ -1,0 +1,50 @@
+import type { AbuseCheckResult, AbuseContext, RateLimitBucket } from "@qyou/types";
+
+/**
+ * AUTH-116 — In-process rate-limit store (dev/test baseline).
+ * Replace with Redis or a shared store for production.
+ */
+const buckets = new Map<string, RateLimitBucket>();
+
+/** Default limits per operation per key (attempts per windowMs). */
+const LIMITS: Record<AbuseContext["operation"], { max: number; windowMs: number }> = {
+  login: { max: 10, windowMs: 60_000 },
+  register: { max: 5, windowMs: 60_000 },
+  "password-reset": { max: 3, windowMs: 300_000 },
+  "challenge-verify": { max: 10, windowMs: 60_000 },
+};
+
+function bucketKey(ctx: AbuseContext): string {
+  const dim = ctx.accountId ?? ctx.ip ?? "anon";
+  return `${ctx.operation}:${dim}`;
+}
+
+/**
+ * Check whether an auth operation should be allowed.
+ * Increments the counter on every call; callers should only invoke
+ * this once per real attempt (not for reads).
+ */
+export function checkAbuse(ctx: AbuseContext): AbuseCheckResult {
+  const { max, windowMs } = LIMITS[ctx.operation];
+  const key = bucketKey(ctx);
+  const now = Date.now();
+
+  let bucket = buckets.get(key);
+  if (!bucket || now >= bucket.resetAt) {
+    bucket = { key, count: 0, resetAt: now + windowMs };
+  }
+
+  bucket.count += 1;
+  buckets.set(key, bucket);
+
+  if (bucket.count > max) {
+    return { allowed: false, code: "RATE_LIMITED", retryAfterMs: bucket.resetAt - now };
+  }
+
+  return { allowed: true };
+}
+
+/** Reset all buckets — useful in tests. */
+export function resetAbuseBuckets(): void {
+  buckets.clear();
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2,6 +2,10 @@ import { config as loadDotenv } from "dotenv";
 
 loadDotenv();
 
+export { createStructuredLogger } from "./logger.js";
+export type { LogLevel, StructuredLogEntry, StructuredLoggerOptions } from "./logger.js";
+export { checkAbuse, resetAbuseBuckets } from "./abuse.js";
+
 function parseNumberEnv(
   name: string,
   fallback: number,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -268,3 +268,55 @@ export type ChallengeErrorCode =
   | "INVALID_SIGNATURE"
   | "RATE_LIMITED"
   | "INTERNAL_ERROR";
+
+// --- Abuse Controls & Device Trust (AUTH-116) ---
+
+/**
+ * Lightweight device-trust record stored per account.
+ * "trusted" = previously verified; "suspicious" = flagged for step-up.
+ */
+export type DeviceTrustRecord = {
+  deviceId: string;
+  accountId: string;
+  userAgent?: string;
+  /** ISO-8601 */
+  firstSeenAt: string;
+  /** ISO-8601 */
+  lastSeenAt: string;
+  trusted: boolean;
+};
+
+/**
+ * A single rate-limit bucket for an abuse-control dimension
+ * (e.g. per-IP login attempts, per-account password resets).
+ */
+export type RateLimitBucket = {
+  key: string;
+  count: number;
+  /** Unix ms — window resets after this point */
+  resetAt: number;
+};
+
+/** Result returned by an abuse-check gate before an auth operation proceeds. */
+export type AbuseCheckResult =
+  | { allowed: true }
+  | { allowed: false; code: AbuseCheckCode; retryAfterMs?: number };
+
+export type AbuseCheckCode =
+  | "RATE_LIMITED"
+  | "ACCOUNT_LOCKED"
+  | "SUSPICIOUS_DEVICE"
+  | "BLOCKED_IP";
+
+/**
+ * Inputs the abuse-control layer consumes on each auth attempt.
+ * All fields are optional so callers supply what they have.
+ */
+export type AbuseContext = {
+  accountId?: string;
+  /** IPv4 or IPv6 address of the caller */
+  ip?: string;
+  deviceId?: string;
+  /** The auth operation being attempted */
+  operation: "login" | "register" | "password-reset" | "challenge-verify";
+};

--- a/scripts/auth-observability-exercise.mjs
+++ b/scripts/auth-observability-exercise.mjs
@@ -1,0 +1,108 @@
+/**
+ * AUTH-114 — Auth observability exercise
+ *
+ * Runs realistic local scenarios against the observability and abuse-control
+ * baseline to catch drift or missing configuration early.
+ *
+ * Usage:
+ *   node scripts/auth-observability-exercise.mjs
+ *
+ * Prerequisites: npm run build (types + config built)
+ * Exit code: 0 = all scenarios passed, 1 = one or more failed.
+ */
+
+// Dynamic import so this works before a full monorepo install.
+const { createStructuredLogger, checkAbuse, resetAbuseBuckets } = await import(
+  "../packages/config/dist/index.js"
+);
+
+let passed = 0;
+let failed = 0;
+
+function scenario(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  ✗ ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+// --- Logger shape ---
+console.log("\n[Scenario group] Structured logger");
+
+scenario("emits valid JSON to stdout", () => {
+  const lines = [];
+  const orig = console.log;
+  console.log = (v) => lines.push(v);
+  const log = createStructuredLogger({ service: "api", component: "auth.login" });
+  log("info", "LOGIN_OK", { accountId: "acc_test" });
+  console.log = orig;
+
+  assert(lines.length === 1, "expected one log line");
+  const entry = JSON.parse(lines[0]);
+  assert(entry.ts, "missing ts");
+  assert(entry.level === "info", "wrong level");
+  assert(entry.event === "LOGIN_OK", "wrong event");
+  assert(entry.service === "api", "wrong service");
+  assert(entry.component === "auth.login", "wrong component");
+  assert(entry.accountId === "acc_test", "missing extra field");
+});
+
+scenario("error level goes to console.error", () => {
+  const lines = [];
+  const orig = console.error;
+  console.error = (v) => lines.push(v);
+  const log = createStructuredLogger({ service: "api" });
+  log("error", "LOGIN_FAIL");
+  console.error = orig;
+  assert(lines.length === 1, "expected one error line");
+  const entry = JSON.parse(lines[0]);
+  assert(entry.level === "error", "wrong level");
+});
+
+// --- Abuse control ---
+console.log("\n[Scenario group] Abuse controls");
+
+scenario("allows requests within rate limit", () => {
+  resetAbuseBuckets();
+  const result = checkAbuse({ operation: "login", ip: "1.2.3.4" });
+  assert(result.allowed === true, "expected allowed");
+});
+
+scenario("blocks after exceeding login limit (10 attempts)", () => {
+  resetAbuseBuckets();
+  let last;
+  for (let i = 0; i < 12; i++) {
+    last = checkAbuse({ operation: "login", ip: "5.5.5.5" });
+  }
+  assert(last.allowed === false, "expected blocked after 12 attempts");
+  assert(last.code === "RATE_LIMITED", `expected RATE_LIMITED, got ${last.code}`);
+  assert(typeof last.retryAfterMs === "number", "expected retryAfterMs");
+});
+
+scenario("buckets are isolated per operation", () => {
+  resetAbuseBuckets();
+  // exhaust login bucket
+  for (let i = 0; i < 12; i++) checkAbuse({ operation: "login", ip: "9.9.9.9" });
+  // register bucket for same IP should still be open
+  const result = checkAbuse({ operation: "register", ip: "9.9.9.9" });
+  assert(result.allowed === true, "register bucket should be independent of login bucket");
+});
+
+scenario("buckets are isolated per account", () => {
+  resetAbuseBuckets();
+  for (let i = 0; i < 12; i++) checkAbuse({ operation: "login", accountId: "acc_a" });
+  const result = checkAbuse({ operation: "login", accountId: "acc_b" });
+  assert(result.allowed === true, "acc_b should not be affected by acc_a's bucket");
+});
+
+// --- Summary ---
+console.log(`\n${passed + failed} scenarios — ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exitCode = 1;

--- a/scripts/auth-observability-monitor.mjs
+++ b/scripts/auth-observability-monitor.mjs
@@ -1,0 +1,107 @@
+/**
+ * AUTH-113 — Auth observability monitor
+ *
+ * Surfaces high-signal operational events across auth workspaces.
+ * Separates expected warnings (missing optional env, dev defaults) from real
+ * failures (missing required config, ad-hoc loggers, build errors).
+ *
+ * Usage:
+ *   node scripts/auth-observability-monitor.mjs
+ *
+ * Exit code: 0 = no errors (warnings are allowed), 1 = one or more errors.
+ */
+
+import { execSync } from "node:child_process";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const IGNORE = new Set(["node_modules", ".git", "dist", ".next", "build", "coverage"]);
+
+const AUTH_DIRS = [
+  path.join(ROOT, "apps", "api", "src", "auth"),
+  path.join(ROOT, "apps", "stellar-service", "src"),
+];
+
+async function walk(dir) {
+  let files = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return files; // dir doesn't exist yet — not an error
+  }
+  for (const e of entries) {
+    if (IGNORE.has(e.name)) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) files.push(...(await walk(full)));
+    else if (e.isFile() && e.name.endsWith(".ts")) files.push(full);
+  }
+  return files;
+}
+
+function run(cmd) {
+  try {
+    execSync(cmd, { stdio: "pipe" });
+    return null;
+  } catch (err) {
+    return err.stderr?.toString() || err.stdout?.toString() || String(err);
+  }
+}
+
+const warnings = [];
+const errors = [];
+
+// --- 1. Logger drift check ---
+for (const dir of AUTH_DIRS) {
+  for (const file of await walk(dir)) {
+    const rel = path.relative(ROOT, file);
+    const text = await readFile(file, "utf8");
+    if (text.includes("function log(") && !text.includes("createStructuredLogger")) {
+      errors.push(`${rel}: ad-hoc logger (use createStructuredLogger from @qyou/config)`);
+    }
+  }
+}
+
+// --- 2. Env baseline warnings (expected in dev, real failures in prod) ---
+const requiredInProd = ["JWT_SECRET"];
+const optional = [
+  "ACCESS_TOKEN_TTL_SECONDS",
+  "REFRESH_TOKEN_TTL_SECONDS",
+  "CORS_ORIGIN",
+  "STELLAR_NETWORK",
+  "STELLAR_HORIZON_URL",
+  "STELLAR_RPC_URL",
+];
+
+const nodeEnv = process.env.NODE_ENV ?? "development";
+for (const key of requiredInProd) {
+  if (!process.env[key]) {
+    if (nodeEnv === "production") errors.push(`${key} is not set (required in production)`);
+    else warnings.push(`${key} is not set — using dev default`);
+  }
+}
+for (const key of optional) {
+  if (!process.env[key]) warnings.push(`${key} is not set — using default`);
+}
+
+// --- 3. Build health check for auth workspaces ---
+const buildError = run("npm run build --workspace @qyou/config --workspace @qyou/types 2>&1");
+if (buildError) errors.push(`build failed:\n${buildError}`);
+
+// --- Output ---
+console.log("=== Auth observability monitor ===");
+console.log(`env: ${nodeEnv}`);
+
+if (warnings.length) {
+  console.log("\nWarnings (expected in dev):");
+  for (const w of warnings) console.log(`  ⚠  ${w}`);
+}
+
+if (errors.length) {
+  console.log("\nErrors (need attention):");
+  for (const e of errors) console.log(`  ✗  ${e}`);
+  process.exitCode = 1;
+} else {
+  console.log("\n✓ No errors detected.");
+}


### PR DESCRIPTION
Closes #431, closes #432, closes #433, closes #434

Adds the four OPS auth observability slices in one contributor-ready batch:

- **AUTH-116** (#434): `AbuseCheckResult`, `AbuseContext`, `DeviceTrustRecord`, `RateLimitBucket` types in `@qyou/types`; `checkAbuse` / `resetAbuseBuckets` helper in `@qyou/config` with in-process rate-limiting (swap the Map for Redis in prod).
- **AUTH-115** (#433): `docs/auth-observability.md` rewritten — covers structured logging, abuse controls, device trust, all scripts, env prereqs, and a contributor quick-start.
- **AUTH-114** (#432): `scripts/auth-observability-exercise.mjs` — 6 fixture scenarios covering logger shape, error routing, rate-limit enforcement, and bucket isolation. Runs clean with `npm run auth:exercise`.
- **AUTH-113** (#431): `scripts/auth-observability-monitor.mjs` — separates dev warnings (missing optional env) from real errors (ad-hoc loggers, build failures, missing prod secrets). Exits 0 in dev, 1 on errors.

Two new root scripts added: `auth:monitor` and `auth:exercise`.