### PR TITLE
feat(web): web auth UX state persistence and validation rules

### DIFF
--- a/apps/web/src/components/AuthStateIndicator.tsx
+++ b/apps/web/src/components/AuthStateIndicator.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface AuthStateIndicatorProps {
+  isAuthenticated: boolean;
+  username?: string;
+  storageType?: string;
+}
+
+export function AuthStateIndicator({
+  isAuthenticated,
+  username,
+  storageType = 'localStorage',
+}: AuthStateIndicatorProps) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '12px' }}>
+      <span
+        style={{
+          width: '8px',
+          height: '8px',
+          borderRadius: '50%',
+          backgroundColor: isAuthenticated ? '#22c55e' : '#ef4444',
+        }}
+      />
+      <span>{isAuthenticated ? `Signed in as ${username ?? 'User'} (${storageType})` : 'Not signed in'}</span>
+    </div>
+  );
+}

--- a/apps/web/src/lib/auth-storage.ts
+++ b/apps/web/src/lib/auth-storage.ts
@@ -1,0 +1,40 @@
+import {
+  persistedStateSchema,
+  type PersistedAuthState,
+  type PersistenceValidationResult,
+} from '@qyou/shared';
+
+const STORAGE_KEY = 'qyou.web_auth_v2';
+
+export function saveAuthState(state: PersistedAuthState): void {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }
+}
+
+export function loadAndValidateAuthState(): PersistenceValidationResult {
+  if (typeof window === 'undefined') {
+    return { isValid: false, reason: 'SSR environment' };
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return { isValid: false, reason: 'No state stored' };
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    const validation = persistedStateSchema.safeParse(parsed);
+    if (!validation.success) {
+      return { isValid: false, reason: 'Invalid state schema' };
+    }
+
+    if (Date.now() > validation.data.expiresAt) {
+      return { isValid: false, reason: 'Session expired' };
+    }
+
+    return { isValid: true, state: validation.data as PersistedAuthState };
+  } catch {
+    return { isValid: false, reason: 'Corrupted JSON' };
+  }
+}

--- a/docs/web-auth-ux-persistence-phase2.md
+++ b/docs/web-auth-ux-persistence-phase2.md
@@ -1,0 +1,15 @@
+# Phase 2 Web Auth UX & State Persistence
+
+This document details Phase 2 specifications for client-side web authentication state persistence, storage validation, and session recovery.
+
+## Architectural Changes
+
+1. **Storage Validation**:
+   - `apps/web/src/lib/auth-storage.ts`: Implemented safe loading and schema validation via `persistedStateSchema`.
+   - Expiration checks preventing stale token restoration.
+
+2. **UX Indicators**:
+   - `AuthStateIndicator`: UI status badge confirming active session persistence and storage mode.
+
+3. **Contracts & Schemas**:
+   - Defined `PersistedAuthState`, `StorageMechanism`, and Zod schemas in `@qyou/shared`.

--- a/packages/shared/src/types/auth-persistence.types.ts
+++ b/packages/shared/src/types/auth-persistence.types.ts
@@ -1,0 +1,15 @@
+export type StorageMechanism = 'localStorage' | 'sessionStorage' | 'memory';
+
+export interface PersistedAuthState {
+  token: string;
+  userId: string;
+  savedAt: number;
+  expiresAt: number;
+  mechanism: StorageMechanism;
+}
+
+export interface PersistenceValidationResult {
+  isValid: boolean;
+  reason?: string;
+  state?: PersistedAuthState;
+}

--- a/packages/shared/src/validation/auth-persistence.schemas.ts
+++ b/packages/shared/src/validation/auth-persistence.schemas.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const persistedStateSchema = z.object({
+  token: z.string().min(1, 'Token cannot be empty.'),
+  userId: z.string().min(1, 'User ID is required.'),
+  savedAt: z.number().positive(),
+  expiresAt: z.number().positive(),
+  mechanism: z.enum(['localStorage', 'sessionStorage', 'memory']),
+});
+
+export const restoreSessionSchema = z.object({
+  sessionKey: z.string().min(1, 'Session key is required.'),
+  autoRefresh: z.boolean().default(true),
+});
+
+export type PersistedStateInput = z.infer<typeof persistedStateSchema>;
+export type RestoreSessionInput = z.infer<typeof restoreSessionSchema>;


### PR DESCRIPTION
Implemented Phase 2 web auth state persistence validation and session recovery utilities.

Summary:
- Built auth-storage.ts with safe storage parsing and Zod validation
- Created AuthStateIndicator React component for web state status
- Added persistedStateSchema & restoreSessionSchema to @qyou/shared
- Documented Phase 2 web auth UX persistence guidelines in docs/web-auth-ux-persistence-phase2.md

close #648
close #647
close #646
close #645