### PR TITLE
feat(auth): Phase 3 login security rules & device recognition validation

### DIFF
--- a/apps/api/src/modules/auth/validators/login-security.validator.ts
+++ b/apps/api/src/modules/auth/validators/login-security.validator.ts
@@ -1,0 +1,21 @@
+import {
+  secureLoginPayloadSchema,
+  type LoginSecurityMetrics,
+} from '@qyou/shared';
+
+export function evaluateLoginRisk(payload: unknown): LoginSecurityMetrics {
+  const parseResult = secureLoginPayloadSchema.safeParse(payload);
+  if (!parseResult.success) {
+    return {
+      riskScore: 100,
+      requireTwoFactor: false,
+      blockReason: 'Payload validation failed',
+    };
+  }
+
+  const isNewDevice = !parseResult.data.device?.isKnownDevice;
+  return {
+    riskScore: isNewDevice ? 45 : 10,
+    requireTwoFactor: isNewDevice,
+  };
+}

--- a/apps/web/src/components/LoginSecurityBadge.tsx
+++ b/apps/web/src/components/LoginSecurityBadge.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface LoginSecurityBadgeProps {
+  riskScore?: number;
+  isKnownDevice?: boolean;
+}
+
+export function LoginSecurityBadge({
+  riskScore = 10,
+  isKnownDevice = true,
+}: LoginSecurityBadgeProps) {
+  const isHighRisk = riskScore > 40;
+  const label = isHighRisk ? 'Unrecognized device (Verification required)' : 'Recognized device';
+  const color = isHighRisk ? '#ea580c' : '#16a34a';
+
+  return (
+    <div style={{ padding: '6px 10px', fontSize: '12px', color, border: `1px solid ${color}`, borderRadius: '4px' }}>
+      {label}
+    </div>
+  );
+}

--- a/docs/registration-login-hardening-phase3-validation.md
+++ b/docs/registration-login-hardening-phase3-validation.md
@@ -1,0 +1,14 @@
+# Phase 3 Registration and Login Hardening Validation
+
+This document outlines Phase 3 security validation procedures for device-aware authentication and login risk scoring.
+
+## Core Implementations
+
+1. **Device Risk Scoring**:
+   - `apps/api/src/modules/auth/validators/login-security.validator.ts`: `evaluateLoginRisk` scoring payloads against unrecognized device access.
+
+2. **Web Security UI Badge**:
+   - `LoginSecurityBadge`: React component reflecting current device recognition status.
+
+3. **Validation Schemas & Interfaces**:
+   - `deviceFingerprintSchema` and `secureLoginPayloadSchema` in `@qyou/shared`.

--- a/packages/shared/src/types/login-security.types.ts
+++ b/packages/shared/src/types/login-security.types.ts
@@ -1,0 +1,18 @@
+export interface DeviceFingerprintPayload {
+  deviceId: string;
+  userAgent: string;
+  ipAddress?: string;
+  isKnownDevice: boolean;
+}
+
+export interface LoginSecurityMetrics {
+  riskScore: number;
+  requireTwoFactor: boolean;
+  blockReason?: string;
+}
+
+export interface SecurityPolicyRules {
+  allowUnrecognizedDevices: boolean;
+  maxFailedLoginsPerIp: number;
+  windowMinutes: number;
+}

--- a/packages/shared/src/validation/login-security.schemas.ts
+++ b/packages/shared/src/validation/login-security.schemas.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const deviceFingerprintSchema = z.object({
+  deviceId: z.string().min(1, 'Device ID is required.'),
+  userAgent: z.string().min(1, 'User agent string is required.'),
+  ipAddress: z.string().ip().optional(),
+  isKnownDevice: z.boolean().default(false),
+});
+
+export const secureLoginPayloadSchema = z.object({
+  email: z.string().trim().toLowerCase().email('Valid email is required.'),
+  password: z.string().min(8, 'Password must be at least 8 characters.'),
+  device: deviceFingerprintSchema.optional(),
+});
+
+export type DeviceFingerprintInput = z.infer<typeof deviceFingerprintSchema>;
+export type SecureLoginPayloadInput = z.infer<typeof secureLoginPayloadSchema>;


### PR DESCRIPTION
Added Phase 3 device recognition validation, login risk scoring, and security status indicators.

Overview:
- Built risk evaluation helper evaluateLoginRisk in login-security.validator.ts
- Added LoginSecurityBadge UI component in apps/web/src/components
- Extended @qyou/shared with deviceFingerprintSchema and secureLoginPayloadSchema
- Formulated validation guidelines in docs/registration-login-hardening-phase3-validation.md

close #653
close #652
close #651
close #650