### PR TITLE
feat(queue): Phase 1 operator moderation controls and audit logging

### DIFF
--- a/apps/api/src/modules/queue/services/queue-moderation.service.ts
+++ b/apps/api/src/modules/queue/services/queue-moderation.service.ts
@@ -1,0 +1,24 @@
+import {
+  queueModerationSchema,
+  type QueueModerationInput,
+  type QueueModerationRecord,
+} from '@qyou/shared';
+
+export class QueueModerationService {
+  private readonly auditLogs: QueueModerationRecord[] = [];
+
+  public async applyModeration(input: QueueModerationInput): Promise<QueueModerationRecord> {
+    const validated = queueModerationSchema.parse(input);
+    const record: QueueModerationRecord = {
+      ...validated,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.auditLogs.push(record);
+    return record;
+  }
+
+  public getLogsForQueue(queueId: string): QueueModerationRecord[] {
+    return this.auditLogs.filter((log) => log.queueId === queueId);
+  }
+}

--- a/apps/web/src/components/QueueModerationBar.tsx
+++ b/apps/web/src/components/QueueModerationBar.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { ModerationAction } from '@qyou/shared';
+
+interface QueueModerationBarProps {
+  queueId: string;
+  isPaused?: boolean;
+  onAction?: (action: ModerationAction) => void;
+}
+
+export function QueueModerationBar({ isPaused = false, onAction }: QueueModerationBarProps) {
+  return (
+    <div style={{ display: 'flex', gap: '8px', padding: '8px 12px', background: '#fff7ed', borderRadius: '6px' }}>
+      <button
+        onClick={() => onAction?.(isPaused ? 'resume' : 'pause')}
+        style={{ padding: '6px 12px', background: isPaused ? '#16a34a' : '#ea580c', color: '#fff', border: 'none', borderRadius: '4px' }}
+      >
+        {isPaused ? 'Resume Queue' : 'Pause Queue'}
+      </button>
+      <button
+        onClick={() => onAction?.('flag')}
+        style={{ padding: '6px 12px', background: '#dc2626', color: '#fff', border: 'none', borderRadius: '4px' }}
+      >
+        Report Issue
+      </button>
+    </div>
+  );
+}

--- a/docs/operator-controls-moderation-phase1.md
+++ b/docs/operator-controls-moderation-phase1.md
@@ -1,0 +1,14 @@
+# Phase 1 Operator Controls & Queue Moderation
+
+This document specifies Phase 1 operator-facing moderation controls, queue pause/resume mechanisms, and audit logging.
+
+## Core Features
+
+1. **Moderation Service & Logging**:
+   - `apps/api/src/modules/queue/services/queue-moderation.service.ts`: `QueueModerationService` recording operator actions with ISO timestamps.
+
+2. **Web Operator Bar**:
+   - `QueueModerationBar`: React control toolbar supporting pause, resume, and reporting actions.
+
+3. **Shared Schemas & Interfaces**:
+   - Defined `QueueModerationRecord`, `ModerationAction`, `queueModerationSchema` in `@qyou/shared`.

--- a/packages/shared/src/types/queue-moderation.types.ts
+++ b/packages/shared/src/types/queue-moderation.types.ts
@@ -1,0 +1,15 @@
+export type ModerationAction = 'pause' | 'resume' | 'flag' | 'unflag' | 'update_capacity';
+
+export interface QueueModerationRecord {
+  queueId: string;
+  operatorId: string;
+  action: ModerationAction;
+  reason?: string;
+  timestamp: string;
+}
+
+export interface OperatorPermissions {
+  operatorId: string;
+  assignedQueueIds: string[];
+  canModerate: boolean;
+}

--- a/packages/shared/src/validation/queue-moderation.schemas.ts
+++ b/packages/shared/src/validation/queue-moderation.schemas.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const queueModerationSchema = z.object({
+  queueId: z.string().min(1, 'Queue ID is required.'),
+  operatorId: z.string().min(1, 'Operator ID is required.'),
+  action: z.enum(['pause', 'resume', 'flag', 'unflag', 'update_capacity']),
+  reason: z.string().max(200).optional(),
+});
+
+export const capacityUpdateSchema = z.object({
+  queueId: z.string().min(1),
+  maxCapacity: z.number().int().positive('Max capacity must be positive.'),
+});
+
+export type QueueModerationInput = z.infer<typeof queueModerationSchema>;
+export type CapacityUpdateInput = z.infer<typeof capacityUpdateSchema>;


### PR DESCRIPTION
Implemented Phase 1 data models, Zod validation schemas, and audit log services for operator-facing queue moderation controls.

Key additions:
- Created QueueModerationService in apps/api for audit logging queue pause/resume actions
- Added QueueModerationBar React component in apps/web/src/components
- Defined queueModerationSchema and capacityUpdateSchema in @qyou/shared
- Documented Phase 1 operator control specifications in docs/operator-controls-moderation-phase1.md

Fixes #741
Fixes #740
Fixes #739
Fixes #738