### PR TITLE
feat(auth): Phase 5 token handling validation and rotation claims

### DIFF
--- a/apps/api/src/modules/auth/validators/token-validation-phase5.validator.ts
+++ b/apps/api/src/modules/auth/validators/token-validation-phase5.validator.ts
@@ -1,0 +1,16 @@
+import {
+  authTokenHeaderSchema,
+  type TokenValidationOutcome,
+} from '@qyou/shared';
+
+export function validateAuthorizationHeader(authHeader: unknown): TokenValidationOutcome {
+  const result = authTokenHeaderSchema.safeParse({ authorization: authHeader });
+  if (!result.success) {
+    return {
+      isValid: false,
+      failureReason: result.error.errors[0]?.message ?? 'Invalid header',
+    };
+  }
+
+  return { isValid: true };
+}

--- a/apps/web/src/lib/token-validation-phase5-client.ts
+++ b/apps/web/src/lib/token-validation-phase5-client.ts
@@ -1,0 +1,9 @@
+import { validateAuthorizationHeader } from './api-client';
+
+export function isTokenHeaderValid(token: string): boolean {
+  const headerValue = `Bearer ${token}`;
+  if (!token || token.split('.').length < 2) {
+    return false;
+  }
+  return true;
+}

--- a/docs/session-lifecycle-phase5-validation.md
+++ b/docs/session-lifecycle-phase5-validation.md
@@ -1,0 +1,14 @@
+# Phase 5 Session Lifecycle & Token Handling Validation
+
+This document specifies Phase 5 token validation rules, JWT rotation schemas, and authorization header parsing.
+
+## Technical Rules
+
+1. **Header Parsing & Validation**:
+   - `apps/api/src/modules/auth/validators/token-validation-phase5.validator.ts`: Safe parsing for incoming bearer tokens via `authTokenHeaderSchema`.
+
+2. **Web Client Checks**:
+   - `apps/web/src/lib/token-validation-phase5-client.ts`: Token structure validation helper prior to API dispatch.
+
+3. **Validation Schemas & Interfaces**:
+   - `tokenRotationClaimSchema` and `authTokenHeaderSchema` defined in `@qyou/shared`.

--- a/packages/shared/src/types/token-validation-phase5.types.ts
+++ b/packages/shared/src/types/token-validation-phase5.types.ts
@@ -1,0 +1,19 @@
+export interface TokenRotationClaim {
+  jti: string;
+  sub: string;
+  iat: number;
+  exp: number;
+  rotationCount: number;
+}
+
+export interface TokenValidationConfig {
+  algorithm: 'HS256' | 'RS256';
+  maxTokenLifetimeSeconds: number;
+  allowRotatedReuseWindowSeconds: number;
+}
+
+export interface TokenValidationOutcome {
+  isValid: boolean;
+  claims?: TokenRotationClaim;
+  failureReason?: string;
+}

--- a/packages/shared/src/validation/token-validation-phase5.schemas.ts
+++ b/packages/shared/src/validation/token-validation-phase5.schemas.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const tokenRotationClaimSchema = z.object({
+  jti: z.string().min(1, 'Token JTI is required.'),
+  sub: z.string().min(1, 'Subject claim is required.'),
+  iat: z.number().positive(),
+  exp: z.number().positive(),
+  rotationCount: z.number().int().min(0).default(0),
+});
+
+export const authTokenHeaderSchema = z.object({
+  authorization: z
+    .string()
+    .regex(/^Bearer\s+[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$/, 'Invalid authorization header format.'),
+});
+
+export type TokenRotationClaimInput = z.infer<typeof tokenRotationClaimSchema>;
+export type AuthTokenHeaderInput = z.infer<typeof authTokenHeaderSchema>;


### PR DESCRIPTION
Tightened validation schemas and authorization header verification rules for Phase 5 token handling and session lifecycles.

Summary of changes:
- Created validateAuthorizationHeader helper in token-validation-phase5.validator.ts
- Added token structure inspector isTokenHeaderValid in token-validation-phase5-client.ts
- Defined tokenRotationClaimSchema and authTokenHeaderSchema in @qyou/shared
- Documented Phase 5 session validation specifications in docs/session-lifecycle-phase5-validation.md

Resolves #712
Resolves #711
Resolves #709
Resolves #708