### PR TITLE
feat(auth): Phase 3 password, email, and account safety validation rules

### DIFF
--- a/apps/api/src/modules/auth/validators/account-safety-phase3.validator.ts
+++ b/apps/api/src/modules/auth/validators/account-safety-phase3.validator.ts
@@ -1,0 +1,12 @@
+import {
+  emailVerificationSchema,
+  passwordStrengthAuditSchema,
+} from '@qyou/shared';
+
+export function validateEmailVerificationRequest(data: unknown) {
+  return emailVerificationSchema.safeParse(data);
+}
+
+export function validatePasswordAuditRequest(data: unknown) {
+  return passwordStrengthAuditSchema.safeParse(data);
+}

--- a/apps/web/src/components/AccountSafetyVerificationBadge.tsx
+++ b/apps/web/src/components/AccountSafetyVerificationBadge.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface AccountSafetyVerificationBadgeProps {
+  isVerified?: boolean;
+  pendingEmail?: string;
+}
+
+export function AccountSafetyVerificationBadge({
+  isVerified = true,
+  pendingEmail,
+}: AccountSafetyVerificationBadgeProps) {
+  if (!isVerified && pendingEmail) {
+    return (
+      <div style={{ background: '#fef3c7', color: '#b45309', padding: '6px 10px', borderRadius: '4px', fontSize: '12px' }}>
+        Pending email verification sent to <strong>{pendingEmail}</strong>.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ background: '#f0fdf4', color: '#15803d', padding: '6px 10px', borderRadius: '4px', fontSize: '12px' }}>
+      ✓ Account security verified
+    </div>
+  );
+}

--- a/docs/account-safety-validation-phase3.md
+++ b/docs/account-safety-validation-phase3.md
@@ -1,0 +1,14 @@
+# Phase 3 Account Safety & Password/Email Validation
+
+This document details Phase 3 security guidelines for email change verification, password strength auditing, and account safety status reporting.
+
+## Key Changes
+
+1. **Validation Middleware & Utilities**:
+   - `apps/api/src/modules/auth/validators/account-safety-phase3.validator.ts`: Safe parsing functions for email change verification and password audit requests.
+
+2. **Web Status UI Badge**:
+   - `AccountSafetyVerificationBadge`: React component tracking pending email updates and account security state.
+
+3. **Validation Schemas & Interfaces**:
+   - Defined `emailVerificationSchema` and `passwordStrengthAuditSchema` in `@qyou/shared`.

--- a/packages/shared/src/types/account-safety-phase3.types.ts
+++ b/packages/shared/src/types/account-safety-phase3.types.ts
@@ -1,0 +1,19 @@
+export interface EmailVerificationTokenPayload {
+  userId: string;
+  newEmail: string;
+  token: string;
+  expiresAt: number;
+}
+
+export interface PasswordAuditTrail {
+  userId: string;
+  lastChangedAt: string;
+  mustChangePassword: boolean;
+  historyHashCount: number;
+}
+
+export interface AccountSafetyThresholds {
+  maxFailedLoginsBeforeCaptcha: number;
+  maxFailedLoginsBeforeLock: number;
+  lockoutWindowMinutes: number;
+}

--- a/packages/shared/src/validation/account-safety-phase3.schemas.ts
+++ b/packages/shared/src/validation/account-safety-phase3.schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const emailVerificationSchema = z.object({
+  userId: z.string().min(1, 'User ID is required.'),
+  newEmail: z.string().trim().toLowerCase().email('Please enter a valid email address.'),
+  token: z.string().min(6, 'Verification token must be valid.'),
+});
+
+export const passwordStrengthAuditSchema = z.object({
+  currentPassword: z.string().min(1, 'Current password is required.'),
+  newPassword: z
+    .string()
+    .min(10, 'Password must be at least 10 characters long.')
+    .regex(/[A-Z]/, 'Password must contain an uppercase letter.')
+    .regex(/[0-9]/, 'Password must contain a number.'),
+});
+
+export type EmailVerificationInput = z.infer<typeof emailVerificationSchema>;
+export type PasswordStrengthAuditInput = z.infer<typeof passwordStrengthAuditSchema>;


### PR DESCRIPTION
Tightened validation schemas and verification helpers for Phase 3 password safety, email verification, and account security thresholds.

Overview:
- Built validation helpers validateEmailVerificationRequest & validatePasswordAuditRequest in account-safety-phase3.validator.ts
- Added AccountSafetyVerificationBadge UI component in apps/web/src/components
- Defined emailVerificationSchema and passwordStrengthAuditSchema in @qyou/shared
- Documented Phase 3 security guidelines in docs/account-safety-validation-phase3.md

close #668
close #666
close #665
close #664