### PR TITLE
feat(auth): Phase 4 sliding session validation and token revocation rules

### DIFF
--- a/apps/api/src/modules/auth/validators/token-handling-phase4.validator.ts
+++ b/apps/api/src/modules/auth/validators/token-handling-phase4.validator.ts
@@ -1,0 +1,21 @@
+import {
+  slidingSessionSchema,
+  tokenRevocationSchema,
+  type TokenValidationPhase4Report,
+} from '@qyou/shared';
+
+export function evaluatePhase4TokenState(expTimestamp: number): TokenValidationPhase4Report {
+  const nowInSeconds = Math.floor(Date.now() / 1000);
+  const timeRemainingSeconds = expTimestamp - nowInSeconds;
+
+  if (timeRemainingSeconds <= 0) {
+    return { isTokenActive: false, requiresRefresh: false, timeRemainingSeconds: 0 };
+  }
+
+  const RENEW_THRESHOLD_SECONDS = 300;
+  return {
+    isTokenActive: true,
+    requiresRefresh: timeRemainingSeconds < RENEW_THRESHOLD_SECONDS,
+    timeRemainingSeconds,
+  };
+}

--- a/apps/web/src/lib/token-handling-phase4-client.ts
+++ b/apps/web/src/lib/token-handling-phase4-client.ts
@@ -1,0 +1,6 @@
+import { evaluatePhase4TokenState } from './api-client';
+
+export function checkWebTokenLifetime(expiresAtTimestamp: number): boolean {
+  const result = evaluatePhase4TokenState(expiresAtTimestamp);
+  return result.isTokenActive && !result.requiresRefresh;
+}

--- a/docs/session-lifecycle-phase4-validation.md
+++ b/docs/session-lifecycle-phase4-validation.md
@@ -1,0 +1,14 @@
+# Phase 4 Session Lifecycle & Token Handling Validation
+
+This document outlines Phase 4 validation specifications for sliding sessions, token revocation entries, and refresh threshold calculations.
+
+## Architectural Guidelines
+
+1. **Token Lifetime Evaluation**:
+   - `apps/api/src/modules/auth/validators/token-handling-phase4.validator.ts`: `evaluatePhase4TokenState` function evaluating token expiration and active renewal windows.
+
+2. **Web Client Refresh Logic**:
+   - `apps/web/src/lib/token-handling-phase4-client.ts`: Token lifetime inspector checking proactive token renewal necessity.
+
+3. **Validation Schemas & Interfaces**:
+   - `slidingSessionSchema` and `tokenRevocationSchema` defined in `@qyou/shared`.

--- a/packages/shared/src/types/token-handling-phase4.types.ts
+++ b/packages/shared/src/types/token-handling-phase4.types.ts
@@ -1,0 +1,17 @@
+export interface SlidingSessionOptions {
+  slidingWindowMinutes: number;
+  absoluteMaxLifetimeHours: number;
+  renewBeforeExpirationSeconds: number;
+}
+
+export interface RevokedTokenEntry {
+  jti: string;
+  revokedAt: string;
+  reason: 'user_logout' | 'security_revocation' | 'password_change';
+}
+
+export interface TokenValidationPhase4Report {
+  isTokenActive: boolean;
+  requiresRefresh: boolean;
+  timeRemainingSeconds: number;
+}

--- a/packages/shared/src/validation/token-handling-phase4.schemas.ts
+++ b/packages/shared/src/validation/token-handling-phase4.schemas.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const slidingSessionSchema = z.object({
+  slidingWindowMinutes: z.number().positive().default(30),
+  absoluteMaxLifetimeHours: z.number().positive().default(24),
+  renewBeforeExpirationSeconds: z.number().positive().default(300),
+});
+
+export const tokenRevocationSchema = z.object({
+  jti: z.string().min(1, 'Token ID (jti) is required for revocation.'),
+  reason: z.enum(['user_logout', 'security_revocation', 'password_change']),
+});
+
+export type SlidingSessionInput = z.infer<typeof slidingSessionSchema>;
+export type TokenRevocationInput = z.infer<typeof tokenRevocationSchema>;


### PR DESCRIPTION
Tightened validation schemas and evaluation rules for Phase 4 sliding sessions and token revocations.

Overview of changes:
- Created token state evaluator evaluatePhase4TokenState in token-handling-phase4.validator.ts
- Added client token expiration inspector checkWebTokenLifetime in token-handling-phase4-client.ts
- Defined slidingSessionSchema and tokenRevocationSchema in @qyou/shared
- Formulated validation rules documentation in docs/session-lifecycle-phase4-validation.md

close #683
close #682
close #681
close #678