### PR TITLE
feat(queue): Phase 1 queue creation & membership data model with edge case handling

### DIFF
--- a/apps/api/src/modules/queue/services/queue-membership.service.ts
+++ b/apps/api/src/modules/queue/services/queue-membership.service.ts
@@ -1,0 +1,49 @@
+import {
+  joinQueueSchema,
+  type EdgeCaseValidationResult,
+  type JoinQueueInput,
+  type QueueMembershipRecord,
+} from '@qyou/shared';
+
+export class QueueMembershipService {
+  private readonly memberships: Map<string, QueueMembershipRecord[]> = new Map();
+
+  public async joinQueue(input: JoinQueueInput): Promise<QueueMembershipRecord> {
+    const validated = joinQueueSchema.parse(input);
+    const existing = this.memberships.get(validated.queueId) ?? [];
+
+    const isDuplicate = existing.some((m) => m.userId === validated.userId);
+    if (isDuplicate) {
+      throw new Error('User is already a member of this queue.');
+    }
+
+    const newRecord: QueueMembershipRecord = {
+      queueId: validated.queueId,
+      userId: validated.userId,
+      positionNumber: existing.length + 1,
+      role: validated.role,
+      joinedAt: new Date().toISOString(),
+    };
+
+    existing.push(newRecord);
+    this.memberships.set(validated.queueId, existing);
+    return newRecord;
+  }
+
+  public validateJoinEdgeCases(queueId: string, userId: string, maxCapacity = 100): EdgeCaseValidationResult {
+    const existing = this.memberships.get(queueId) ?? [];
+    const duplicateDetected = existing.some((m) => m.userId === userId);
+    const capacityExceeded = existing.length >= maxCapacity;
+
+    return {
+      isPermitted: !duplicateDetected && !capacityExceeded,
+      duplicateDetected,
+      capacityExceeded,
+      errorMessage: duplicateDetected
+        ? 'Duplicate join attempt'
+        : capacityExceeded
+        ? 'Queue at maximum capacity'
+        : undefined,
+    };
+  }
+}

--- a/apps/web/src/components/QueueMembershipBadge.tsx
+++ b/apps/web/src/components/QueueMembershipBadge.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import type { QueueMemberRole } from '@qyou/shared';
+
+interface QueueMembershipBadgeProps {
+  positionNumber?: number;
+  role?: QueueMemberRole;
+}
+
+export function QueueMembershipBadge({
+  positionNumber = 1,
+  role = 'member',
+}: QueueMembershipBadgeProps) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '6px 12px', background: '#eff6ff', borderRadius: '6px' }}>
+      <span style={{ fontWeight: 'bold', color: '#1d4ed8' }}>#{positionNumber} in queue</span>
+      {role !== 'member' && (
+        <span style={{ fontSize: '11px', padding: '2px 6px', background: '#dbeafe', color: '#1e40af', borderRadius: '4px' }}>
+          {role.replace('_', ' ').toUpperCase()}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/docs/queue-creation-membership-phase1.md
+++ b/docs/queue-creation-membership-phase1.md
@@ -1,0 +1,14 @@
+# Phase 1 Queue Creation & Membership Data Model
+
+This document outlines Phase 1 specifications for queue creation data models, membership position assignments, and join edge-case validations.
+
+## Architecture & Features
+
+1. **Membership Service & Edge Cases**:
+   - `apps/api/src/modules/queue/services/queue-membership.service.ts`: Implemented `QueueMembershipService` handling position numbers and duplicate join detection.
+
+2. **Web Membership Badge**:
+   - `QueueMembershipBadge`: React component rendering queue position numbers and member role tags.
+
+3. **Validation Schemas & Interfaces**:
+   - `joinQueueSchema` and `newQueueOptionsSchema` in `@qyou/shared`.

--- a/packages/shared/src/types/queue-membership.types.ts
+++ b/packages/shared/src/types/queue-membership.types.ts
@@ -1,0 +1,23 @@
+export type QueueMemberRole = 'member' | 'vip' | 'queue_buddy' | 'operator';
+
+export interface QueueMembershipRecord {
+  queueId: string;
+  userId: string;
+  positionNumber: number;
+  role: QueueMemberRole;
+  joinedAt: string;
+  estimatedTurnTime?: string;
+}
+
+export interface QueueCreationOptions {
+  name: string;
+  maxCapacity?: number;
+  allowQueueBuddies: boolean;
+}
+
+export interface EdgeCaseValidationResult {
+  isPermitted: boolean;
+  duplicateDetected: boolean;
+  capacityExceeded: boolean;
+  errorMessage?: string;
+}

--- a/packages/shared/src/validation/queue-membership.schemas.ts
+++ b/packages/shared/src/validation/queue-membership.schemas.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const queueMemberRoleSchema = z.enum(['member', 'vip', 'queue_buddy', 'operator']);
+
+export const joinQueueSchema = z.object({
+  queueId: z.string().min(1, 'Queue ID is required.'),
+  userId: z.string().min(1, 'User ID is required.'),
+  role: queueMemberRoleSchema.default('member'),
+});
+
+export const newQueueOptionsSchema = z.object({
+  name: z.string().trim().min(3, 'Name must be at least 3 characters long.').max(80),
+  maxCapacity: z.number().int().positive().optional(),
+  allowQueueBuddies: z.boolean().default(true),
+});
+
+export type JoinQueueInput = z.infer<typeof joinQueueSchema>;
+export type NewQueueOptionsInput = z.infer<typeof newQueueOptionsSchema>;


### PR DESCRIPTION
Refined the Phase 1 queue creation and membership data models, Zod validation schemas, and edge case validators.

Summary:
- Built QueueMembershipService in apps/api for position tracking and duplicate join detection
- Added QueueMembershipBadge UI component in apps/web/src/components
- Defined joinQueueSchema and newQueueOptionsSchema in @qyou/shared
- Documented Phase 1 queue creation specifications in docs/queue-creation-membership-phase1.md

Fixes #727
Fixes #726
Fixes #725
Fixes #723