### PR TITLE
docs(queue): Phase 1 operational contract for shared queue data models & API envelopes

### DIFF
--- a/apps/api/src/shared/errors/queue-domain-error.ts
+++ b/apps/api/src/shared/errors/queue-domain-error.ts
@@ -1,0 +1,20 @@
+import type { QueueErrorCode, QueueErrorPayload } from '@qyou/shared';
+
+export class QueueDomainError extends Error {
+  public readonly code: QueueErrorCode;
+  public readonly statusCode: number;
+
+  constructor(code: QueueErrorCode, message: string, statusCode = 400) {
+    super(message);
+    this.code = code;
+    this.statusCode = statusCode;
+    Object.setPrototypeOf(this, QueueDomainError.prototype);
+  }
+
+  public toPayload(): QueueErrorPayload {
+    return {
+      code: this.code,
+      message: this.message,
+    };
+  }
+}

--- a/apps/web/src/lib/queue-api-contract-client.ts
+++ b/apps/web/src/lib/queue-api-contract-client.ts
@@ -1,0 +1,17 @@
+import type { QueueApiEnvelope, QueueErrorPayload } from '@qyou/shared';
+
+export function unwrapQueueApiResponse<T>(response: QueueApiEnvelope<T>): T {
+  if (!response.success || response.error) {
+    const errorPayload: QueueErrorPayload = response.error ?? {
+      code: 'INVALID_PARAMS',
+      message: 'Unknown API error',
+    };
+    throw new Error(`[${errorPayload.code}] ${errorPayload.message}`);
+  }
+
+  if (response.data === undefined) {
+    throw new Error('API response contained no payload data');
+  }
+
+  return response.data;
+}

--- a/docs/shared-queue-models-operational-contract-phase1.md
+++ b/docs/shared-queue-models-operational-contract-phase1.md
@@ -1,0 +1,15 @@
+# Phase 1 Shared Queue Models & API Operational Contract
+
+This document specifies the operational contract for shared queue data models, API payload envelopes, and standardized error formats across `@qyou/shared`, `apps/api`, and `apps/web`.
+
+## Operational Specifications
+
+1. **API Envelope Format**:
+   - `QueueApiEnvelope<T>`: Standardized response wrapper containing `success: boolean`, `data?: T`, and `error?: QueueErrorPayload`.
+   - `PaginationMeta`: Standardized page numbers, total counts, and limit metadata.
+
+2. **Error Taxonomy & Standard Codes**:
+   - `QUEUE_NOT_FOUND`, `QUEUE_FULL`, `DUPLICATE_MEMBERSHIP`, `UNAUTHORIZED_OPERATOR`.
+
+3. **Validation & Type Exports**:
+   - Zod schemas `queueApiEnvelopeSchema` and `paginationParamsSchema` exported from `@qyou/shared`.

--- a/packages/shared/src/types/queue-api-contract.types.ts
+++ b/packages/shared/src/types/queue-api-contract.types.ts
@@ -1,0 +1,26 @@
+export type QueueErrorCode =
+  | 'QUEUE_NOT_FOUND'
+  | 'QUEUE_FULL'
+  | 'DUPLICATE_MEMBERSHIP'
+  | 'UNAUTHORIZED_OPERATOR'
+  | 'INVALID_PARAMS';
+
+export interface QueueErrorPayload {
+  code: QueueErrorCode;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+export interface QueueApiEnvelope<T> {
+  success: boolean;
+  data?: T;
+  error?: QueueErrorPayload;
+  meta?: PaginationMeta;
+}

--- a/packages/shared/src/validation/queue-api-contract.schemas.ts
+++ b/packages/shared/src/validation/queue-api-contract.schemas.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const queueErrorCodeSchema = z.enum([
+  'QUEUE_NOT_FOUND',
+  'QUEUE_FULL',
+  'DUPLICATE_MEMBERSHIP',
+  'UNAUTHORIZED_OPERATOR',
+  'INVALID_PARAMS',
+]);
+
+export const queueErrorPayloadSchema = z.object({
+  code: queueErrorCodeSchema,
+  message: z.string().min(1, 'Error message is required.'),
+  details: z.record(z.unknown()).optional(),
+});
+
+export const paginationParamsSchema = z.object({
+  page: z.number().int().positive().default(1),
+  limit: z.number().int().positive().max(100).default(20),
+});
+
+export type QueueErrorPayloadInput = z.infer<typeof queueErrorPayloadSchema>;
+export type PaginationParamsInput = z.infer<typeof paginationParamsSchema>;


### PR DESCRIPTION
Defined the Phase 1 operational contracts for shared queue domain models, API response wrappers, and standard error payloads.

Key additions:
- Created operational contract specifications in docs/shared-queue-models-operational-contract-phase1.md
- Implemented QueueDomainError class in apps/api/src/shared/errors
- Added response unwrapper helper unwrapQueueApiResponse in apps/web/src/lib
- Defined queueErrorPayloadSchema and paginationParamsSchema in @qyou/shared

Fixes #750
Fixes #749
Fixes #744
Fixes #742