### PR TITLE
docs(auth): sprint-2 auth and identity flow docs for #633, #634, #635, #636

### DIFF
--- a/docs/session-lifecycle-phase2-rollout.md
+++ b/docs/session-lifecycle-phase2-rollout.md
@@ -1,0 +1,31 @@
+# Phase 2 Session Lifecycle & Token Handling Rollout
+
+This document sets out the rollout plan for Phase 2 session lifecycle and token handling changes,
+covering the order of deployment and how to back out.
+
+## Architectural Guidelines
+
+1. **Shared contracts ship first**:
+   - `packages/shared/src/validation/auth.schemas.ts` and
+     `packages/shared/src/types/auth.types.ts` are published before either app consumes them, since
+     `@qyou/shared` builds ahead of the workspaces in the root `build` script.
+
+2. **API before web**:
+   - `apps/api/src/modules/auth/services/auth.service.ts` and
+     `apps/api/src/modules/auth/routes/auth.routes.ts` roll out next. The API tolerates clients that
+     have not yet updated.
+
+3. **Web last**:
+   - `apps/web/src/lib/auth-context.tsx` and `apps/web/src/lib/auth-storage.ts` are updated once the
+     API is live, so the browser never depends on an endpoint that has not shipped.
+
+## Rollout Sequence
+
+1. Merge shared contract changes; confirm `@qyou/shared` builds.
+2. Deploy the API; confirm existing sessions still authenticate.
+3. Deploy the web app; confirm sign-in, refresh, and sign-out.
+
+## Rollback
+
+Each step is independently revertible. Because the API stays backward compatible through step 2,
+rolling back the web app alone restores the previous behaviour without invalidating live sessions.

--- a/docs/session-lifecycle-phase2-validation.md
+++ b/docs/session-lifecycle-phase2-validation.md
@@ -1,0 +1,36 @@
+# Phase 2 Session Lifecycle & Token Handling Validation
+
+This document records the Phase 2 validation rules for session lifecycle and token handling, so that
+route, service, and form layers reject the same input for the same reasons.
+
+## Architectural Guidelines
+
+1. **Contract-first validation**:
+   - `packages/shared/src/validation/auth.schemas.ts`: the shared zod schemas remain the single
+     source of truth. Phase 2 tightening extends these schemas rather than adding parallel checks
+     inside `apps/api` or `apps/web`.
+
+2. **Service-level enforcement**:
+   - `apps/api/src/modules/auth/services/auth.service.ts`: session and token operations validate
+     through the shared schemas before touching the repository layer, so an invalid session never
+     reaches persistence.
+
+3. **Route-level enforcement**:
+   - `apps/api/src/modules/auth/routes/auth.routes.ts`: request bodies are parsed with the same
+     schemas, so a rejected payload produces the same error shape whether it fails at the route or
+     in the service.
+
+4. **Web parity**:
+   - `apps/web/src/lib/auth-context.tsx` and `apps/web/src/lib/api-client.ts` surface the API's
+     validation errors unchanged, rather than re-deriving their own messages.
+
+## Validation Rules
+
+- A session is invalid if its expiry is absent, non-numeric, or already in the past.
+- A token is invalid if it is empty, malformed, or missing its expiry claim.
+- Validation failures are reported as errors, never as a silent fallback to "no session".
+
+## Test Expectations
+
+- `apps/api/src/modules/auth/tests/auth.service.test.ts`: service-level rejection paths.
+- `apps/api/src/modules/auth/tests/auth.routes.test.ts`: route-level integration paths.

--- a/docs/shared-auth-contracts-phase2-boundary.md
+++ b/docs/shared-auth-contracts-phase2-boundary.md
@@ -1,0 +1,31 @@
+# Phase 2 Shared Auth Contracts — Package Boundary
+
+This document defines how `@qyou/shared` is consumed across the workspace for Phase 2 auth contract
+work, and what must not cross the boundary.
+
+## Architectural Guidelines
+
+1. **Single public entry point**:
+   - `packages/shared/src/index.ts` is the only surface consumers import from. Deep imports into
+     `packages/shared/src/validation/*` or `packages/shared/src/types/*` bypass the boundary and
+     couple consumers to the internal file layout.
+
+2. **Build order is enforced by the workspace**:
+   - The root `postinstall` and `build` scripts build `@qyou/shared` before the apps, so a consumer
+     never compiles against stale contract output.
+
+3. **Consumers**:
+   - `apps/api/src/modules/auth/`: imports schemas and types for enforcement.
+   - `apps/web/src/lib/api-client.ts` and `auth-context.tsx`: import the same types so request and
+     response shapes cannot drift between client and server.
+
+## What Must Not Cross
+
+- **No app-specific code in `@qyou/shared`.** No Express types, no React types, no storage adapters.
+- **No dependency from `@qyou/shared` back to `apps/*`.** The dependency arrow points one way only.
+- **No duplicated schema definitions in consumers.** Extend the shared schema instead.
+
+## Verification
+
+`npm run typecheck` at the root covers every workspace, so a broken boundary surfaces as a type
+error rather than as a runtime mismatch.

--- a/docs/shared-auth-contracts-phase2-responsibilities.md
+++ b/docs/shared-auth-contracts-phase2-responsibilities.md
@@ -1,0 +1,27 @@
+# Phase 2 Shared Auth Contracts — Responsibility Split
+
+This document separates the responsibilities for shared auth contracts and schema evolution, so that
+each layer owns one job and the same rule is not implemented twice.
+
+## Architectural Guidelines
+
+1. **`@qyou/shared` owns the contract**:
+   - `packages/shared/src/validation/auth.schemas.ts`: defines what a valid payload is.
+   - `packages/shared/src/types/auth.types.ts`: defines the types derived from those schemas.
+   - It owns shape and constraints. It does not know about HTTP, storage, or React.
+
+2. **`apps/api` owns enforcement and persistence**:
+   - `apps/api/src/modules/auth/services/auth.service.ts`: applies business rules.
+   - `apps/api/src/modules/auth/repositories/`: owns storage.
+   - `apps/api/src/modules/auth/routes/auth.routes.ts`: owns transport and status codes.
+   - The API decides what an invalid payload *means*; it does not redefine what invalid *is*.
+
+3. **`apps/web` owns presentation**:
+   - `apps/web/src/lib/auth-context.tsx`: owns client session state.
+   - `apps/web/src/lib/api-client.ts`: owns transport to the API.
+   - The web app renders errors the API returns; it does not invent its own validation messages.
+
+## Boundary Rule
+
+Validation logic belongs in `@qyou/shared`. If a rule is duplicated in `apps/api` or `apps/web`, the
+two copies will drift, and the drift will only surface as inconsistent error messages in production.


### PR DESCRIPTION
Adds 4 documents for the sprint-2 **Auth and Identity Flows** theme.

Closes #633
Closes #634
Closes #635
Closes #636

## Files added

| Path |
|---|
| `docs/session-lifecycle-phase2-rollout.md` |
| `docs/session-lifecycle-phase2-validation.md` |
| `docs/shared-auth-contracts-phase2-boundary.md` |
| `docs/shared-auth-contracts-phase2-responsibilities.md` |

## Notes

- **Documentation only.** No application code changes, so nothing in `apps/api`, `apps/web`, or `packages/shared` is touched.
- Follows the existing `docs/` convention for this sprint (`<focus>-phase<N>-<action>.md`, `## Architectural Guidelines` section), matching files such as `session-lifecycle-phase4-validation.md` and `shared-auth-contracts-phase4.md`.
- Every file is under 50 lines, and all referenced paths point at modules that exist on `main` today.
- All filenames are new — nothing existing in `docs/` is modified or renamed.
- Branched from `d7c546f` (current upstream `main`), so the PR merges cleanly.