### PR TITLE
docs(auth): sprint-2 auth and identity flow docs for #637, #638, #639, #643

### DIFF
--- a/docs/account-safety-phase2-validation.md
+++ b/docs/account-safety-phase2-validation.md
@@ -1,0 +1,33 @@
+# Phase 2 Password, Email & Account Safety Validation
+
+This document records the Phase 2 validation rules for password, email, and account safety flows,
+keeping the rules in one place across API routes, services, and web forms.
+
+## Architectural Guidelines
+
+1. **Shared schemas own the rules**:
+   - `packages/shared/src/validation/account-safety.schemas.ts`: password strength, email format,
+     and account safety payload shapes.
+   - `packages/shared/src/types/account-safety.types.ts`: the derived types consumers use.
+
+2. **Service enforcement**:
+   - `apps/api/src/modules/auth/services/account-safety.service.ts`: applies the rules before any
+     state change, so a rejected request never partially mutates an account.
+
+3. **Route and form parity**:
+   - `apps/api/src/modules/auth/routes/auth.routes.ts` parses with the shared schema.
+   - `apps/web/src/lib/api-client.ts` sends payloads typed from the same contract, so a form cannot
+     submit a shape the API will refuse.
+
+## Validation Rules
+
+- **Email** must be structurally valid and normalised consistently before comparison, so that
+  case differences never create a duplicate account.
+- **Password** must satisfy the shared strength schema. The rule lives in the schema, not in the
+  form, so the API cannot be bypassed by calling it directly.
+- **Failures are explicit.** A safety check that cannot complete is an error, never a silent pass.
+
+## Test Expectations
+
+- `apps/api/src/modules/auth/tests/auth.service.test.ts`: rejection paths per rule.
+- `apps/api/src/modules/auth/tests/auth.routes.test.ts`: the same rules through the route.

--- a/docs/shared-auth-contracts-phase2-e2e-coverage.md
+++ b/docs/shared-auth-contracts-phase2-e2e-coverage.md
@@ -1,0 +1,34 @@
+# Phase 2 Shared Auth Contracts — End-to-End Coverage
+
+This document specifies the end-to-end coverage expected for Phase 2 shared auth contracts, so a
+contract change cannot land green while breaking a consumer.
+
+## Architectural Guidelines
+
+1. **Contract tests belong with the contract**:
+   - `packages/shared/src/validation/auth.schemas.ts`: each schema is exercised directly with both a
+     valid and an invalid payload, independent of any app.
+
+2. **Service and route coverage**:
+   - `apps/api/src/modules/auth/tests/auth.service.test.ts`: service behaviour against the shared
+     schemas.
+   - `apps/api/src/modules/auth/tests/auth.routes.test.ts`: the same payloads driven through the
+     route, confirming the error shape survives transport.
+
+3. **Web integration**:
+   - `apps/web/src/lib/api-client.ts` and `auth-context.tsx` are covered against a response built
+     from the shared types, so the client cannot assume a field the contract does not promise.
+
+## Coverage Matrix
+
+| Layer | Valid payload | Invalid payload | Error shape |
+|---|---|---|---|
+| `@qyou/shared` schema | ✔ | ✔ | n/a |
+| API service | ✔ | ✔ | ✔ |
+| API route | ✔ | ✔ | ✔ |
+| Web client | ✔ | ✔ | ✔ |
+
+## Rule
+
+A contract change is only complete when the same payload has been asserted at every row above.
+Testing the schema alone proves the rule exists, not that anyone applies it.

--- a/docs/shared-auth-contracts-phase2-rollout.md
+++ b/docs/shared-auth-contracts-phase2-rollout.md
@@ -1,0 +1,33 @@
+# Phase 2 Shared Auth Contracts Rollout
+
+This document sets out the rollout plan for Phase 2 shared auth contract and schema evolution
+changes across `@qyou/shared`, `apps/api`, and `apps/web`.
+
+## Architectural Guidelines
+
+1. **The shared package leads**:
+   - `packages/shared/src/validation/auth.schemas.ts` and
+     `packages/shared/src/types/auth.types.ts` ship first. The root `postinstall` and `build`
+     scripts already build `@qyou/shared` ahead of the apps, so consumers compile against the new
+     contract rather than a stale one.
+
+2. **The API adopts next**:
+   - `apps/api/src/modules/auth/`: adopts the new contract while continuing to accept the previous
+     payload shape, so no client is broken mid-rollout.
+
+3. **The web app adopts last**:
+   - `apps/web/src/lib/api-client.ts` and `auth-context.tsx`: updated once the API accepts both
+     shapes.
+
+## Rollout Sequence
+
+1. **Publish the contract.** Merge shared changes; confirm `@qyou/shared` builds.
+2. **Adopt in the API.** Deploy with both shapes accepted; confirm existing clients still work.
+3. **Adopt in the web app.** Deploy; confirm auth flows end to end.
+4. **Remove the compatibility path.** Only once no client sends the old shape.
+
+## Rollback
+
+Steps 1–3 are independently revertible because step 2 keeps the API backward compatible. Step 4 is
+the point of no return: after it, rolling back the web app breaks auth, so it must be a separate
+deployment rather than bundled with step 3.

--- a/docs/shared-auth-contracts-phase2-validation.md
+++ b/docs/shared-auth-contracts-phase2-validation.md
@@ -1,0 +1,32 @@
+# Phase 2 Shared Auth Contracts Validation
+
+This document records how validation is tightened for Phase 2 shared auth contracts and schema
+evolution, without duplicating rules across the workspace.
+
+## Architectural Guidelines
+
+1. **Schemas are the rule**:
+   - `packages/shared/src/validation/auth.schemas.ts`: tightening means narrowing an existing schema
+     — required fields, bounded lengths, explicit enums — not adding a second check elsewhere.
+
+2. **Types follow schemas**:
+   - `packages/shared/src/types/auth.types.ts`: types are derived from the schemas so a narrowed
+     schema produces a compile error in any consumer that relied on the looser shape.
+
+3. **Consumers enforce, they do not redefine**:
+   - `apps/api/src/modules/auth/services/auth.service.ts` and
+     `apps/api/src/modules/auth/routes/auth.routes.ts` parse with the shared schema.
+   - `apps/web/src/lib/api-client.ts` uses the shared types for the same request bodies.
+
+## Schema Evolution Rules
+
+- **Narrowing is a breaking change.** Tightening a field that consumers already send requires the
+  API to ship first, per the Phase 2 rollout sequence.
+- **Additive fields are optional first.** A new required field breaks existing clients; introduce it
+  as optional, migrate consumers, then require it.
+- **Never fork a schema to work around a consumer.** A second schema is drift with extra steps.
+
+## Verification
+
+`npm run typecheck` at the root fails on any consumer left behind by a narrowed schema, which is the
+intended signal — not something to suppress with a cast.


### PR DESCRIPTION
Adds 4 documents for the sprint-2 **Auth and Identity Flows** theme.

Closes #637
Closes #638
Closes #639
Closes #643

## Files added

| Path |
|---|
| `docs/account-safety-phase2-validation.md` |
| `docs/shared-auth-contracts-phase2-e2e-coverage.md` |
| `docs/shared-auth-contracts-phase2-rollout.md` |
| `docs/shared-auth-contracts-phase2-validation.md` |

## Notes

- **Documentation only.** No application code changes, so nothing in `apps/api`, `apps/web`, or `packages/shared` is touched.
- Follows the existing `docs/` convention for this sprint (`<focus>-phase<N>-<action>.md`, `## Architectural Guidelines` section), matching files such as `session-lifecycle-phase4-validation.md` and `shared-auth-contracts-phase4.md`.
- Every file is under 50 lines, and all referenced paths point at modules that exist on `main` today.
- All filenames are new — nothing existing in `docs/` is modified or renamed.
- Branched from `d7c546f` (current upstream `main`), so the PR merges cleanly.