### PR TITLE
docs(auth): sprint-2 auth and identity flow docs for #649, #655, #658, #667

### DIFF
--- a/docs/account-safety-phase3-e2e-coverage.md
+++ b/docs/account-safety-phase3-e2e-coverage.md
@@ -1,0 +1,34 @@
+# Phase 3 Password, Email & Account Safety — End-to-End Coverage
+
+This document specifies the end-to-end coverage expected for Phase 3 password, email, and account
+safety flows.
+
+## Architectural Guidelines
+
+1. **Schema-level coverage**:
+   - `packages/shared/src/validation/account-safety.schemas.ts` and
+     `account-safety-phase3.schemas.ts`: each rule is exercised with a passing and a failing payload
+     directly against the schema.
+
+2. **Service-level coverage**:
+   - `apps/api/src/modules/auth/services/account-safety.service.ts`, covered by
+     `apps/api/src/modules/auth/tests/auth.service.test.ts`.
+
+3. **Route-level coverage**:
+   - `apps/api/src/modules/auth/routes/auth.routes.ts`, covered by
+     `apps/api/src/modules/auth/tests/auth.routes.test.ts`.
+
+## What End-to-End Means Here
+
+A safety flow is only covered when a single scenario is asserted from payload to persisted outcome.
+Three specific cases must be covered because each fails differently:
+
+- **The happy path** — the change applies and is persisted.
+- **The rejected path** — validation fails and **nothing is mutated**. This is the case unit tests
+  most often miss: a rule can reject correctly while a partial write has already happened.
+- **The idempotent repeat** — replaying the same request does not produce a second effect.
+
+## Rule
+
+Coverage that stops at the schema proves the rule is expressible, not that it is enforced. Every row
+above must be asserted for a Phase 3 safety flow to count as covered.

--- a/docs/session-lifecycle-phase3-responsibilities.md
+++ b/docs/session-lifecycle-phase3-responsibilities.md
@@ -1,0 +1,35 @@
+# Phase 3 Session Lifecycle & Token Handling — Responsibility Split
+
+This document separates the responsibilities for session lifecycle and token handling at Phase 3, so
+that no two layers both believe they own the session.
+
+## Architectural Guidelines
+
+1. **`@qyou/shared` owns the shape**:
+   - `packages/shared/src/validation/auth.schemas.ts` and
+     `packages/shared/src/types/auth.types.ts`: what a session and a token *are*. No lifetime
+     policy, no storage.
+
+2. **`apps/api` owns the lifetime**:
+   - `apps/api/src/modules/auth/services/auth.service.ts`: issues, refreshes, and revokes. The API
+     is the only authority on whether a session is still valid.
+   - `apps/api/src/modules/auth/repositories/`: persists session state.
+
+3. **`apps/web` owns the local copy**:
+   - `apps/web/src/lib/auth-storage.ts`: persists the client's copy.
+   - `apps/web/src/lib/auth-context.tsx`: exposes it to components.
+   - `apps/web/src/lib/web-auth-sync.ts`: keeps tabs consistent.
+
+## The Split That Matters
+
+The web app holds a **cache**, not the truth. It may decide *when to ask* — for example, refreshing
+proactively before expiry — but it must never decide that a session is still valid when the API says
+otherwise.
+
+Practically: a client-side expiry check is an optimisation to avoid a doomed request. It is not
+authorisation. If the two disagree, the API wins and the client discards its copy.
+
+## Consequence
+
+Because the API is authoritative, revocation works: clearing server-side state ends the session on
+the next request regardless of what the browser still holds.

--- a/docs/session-lifecycle-phase3-validation.md
+++ b/docs/session-lifecycle-phase3-validation.md
@@ -1,0 +1,36 @@
+# Phase 3 Session Lifecycle & Token Handling Validation
+
+This document records the Phase 3 validation rules for session lifecycle and token handling, building
+on the Phase 2 rules rather than replacing them.
+
+## Architectural Guidelines
+
+1. **Shared schemas remain authoritative**:
+   - `packages/shared/src/validation/auth.schemas.ts`: session and token payload shapes.
+   - Phase 3 narrows these schemas; it does not introduce a second validation path.
+
+2. **Service-level checks**:
+   - `apps/api/src/modules/auth/services/auth.service.ts`: validates before issuing or refreshing,
+     so an invalid session is never persisted or returned.
+
+3. **Route-level checks**:
+   - `apps/api/src/modules/auth/routes/auth.routes.ts`: parses with the same schemas so the error
+     shape is identical whether a request fails at transport or in the service.
+
+4. **Client parity**:
+   - `apps/web/src/lib/auth-storage-hydrator.ts`: validates rehydrated state against the shared
+     schema before trusting it, rather than casting whatever was stored.
+
+## Validation Rules
+
+- **Expiry must be present and numeric.** A session with an absent or unparseable expiry is invalid,
+  not "valid until proven otherwise".
+- **Rehydrated state is untrusted input.** Stored state can be edited by anyone with the browser; it
+  is validated on read exactly like a network payload.
+- **A failed check is an error, not a downgrade.** Falling back to an anonymous state silently hides
+  the reason from both the user and the logs.
+
+## Test Expectations
+
+- `apps/api/src/modules/auth/tests/auth.service.test.ts`: issue, refresh, and revoke paths.
+- `apps/api/src/modules/auth/tests/auth.routes.test.ts`: the same rules through the route.

--- a/docs/web-auth-ux-phase2-rollout.md
+++ b/docs/web-auth-ux-phase2-rollout.md
@@ -1,0 +1,37 @@
+# Phase 2 Web Auth UX & State Persistence Rollout
+
+This document sets out the rollout plan for Phase 2 web auth UX and state persistence changes.
+
+## Architectural Guidelines
+
+1. **Shared state contracts first**:
+   - `packages/shared/src/validation/web-auth-state.schemas.ts` and
+     `packages/shared/src/validation/auth-persistence.schemas.ts`: the persisted-state shape is a
+     contract, so it ships before the client that writes it.
+
+2. **Persistence layer next**:
+   - `apps/web/src/lib/auth-storage.ts` and `auth-storage-hydrator.ts`: writing and rehydrating
+     stored auth state. This changes what lives in a user's browser, so it rolls out before any UI
+     depends on the new shape.
+
+3. **UX last**:
+   - `apps/web/src/lib/auth-context.tsx` and `web-auth-sync.ts`: the context and cross-tab sync
+     consume hydrated state once the storage format is live.
+
+## Rollout Sequence
+
+1. Merge shared state schemas; confirm `@qyou/shared` builds.
+2. Ship the persistence layer able to **read both** the old and new stored shapes.
+3. Ship the UX changes.
+4. Drop the old-shape reader once returning users have re-authenticated.
+
+## The Returning-User Problem
+
+Unlike an API rollout, stored state is already on users' machines and cannot be migrated server
+side. Step 2 must therefore tolerate the previous shape rather than assume the new one — a hydrator
+that throws on an unrecognised value logs every returning user out on deploy.
+
+## Rollback
+
+Steps 1–3 revert cleanly while step 2 still reads both shapes. After step 4, a rollback strands
+anyone whose stored state was written in the new format, so schedule it as its own deployment.


### PR DESCRIPTION
Adds 4 documents for the sprint-2 **Auth and Identity Flows** theme.

Closes #649
Closes #655
Closes #658
Closes #667

## Files added

| Path |
|---|
| `docs/account-safety-phase3-e2e-coverage.md` |
| `docs/session-lifecycle-phase3-responsibilities.md` |
| `docs/session-lifecycle-phase3-validation.md` |
| `docs/web-auth-ux-phase2-rollout.md` |

## Notes

- **Documentation only.** No application code changes, so nothing in `apps/api`, `apps/web`, or `packages/shared` is touched.
- Follows the existing `docs/` convention for this sprint (`<focus>-phase<N>-<action>.md`, `## Architectural Guidelines` section), matching files such as `session-lifecycle-phase4-validation.md` and `shared-auth-contracts-phase4.md`.
- Every file is under 50 lines, and all referenced paths point at modules that exist on `main` today.
- All filenames are new — nothing existing in `docs/` is modified or renamed.
- Branched from `d7c546f` (current upstream `main`), so the PR merges cleanly.