### PR TITLE
docs(auth): sprint-2 auth and identity flow docs for #685, #688, #691, #692

### DIFF
--- a/docs/account-safety-phase4-boundary.md
+++ b/docs/account-safety-phase4-boundary.md
@@ -1,0 +1,33 @@
+# Phase 4 Password, Email & Account Safety — Package Boundary
+
+This document defines the package boundary for Phase 4 password, email, and account safety flows.
+
+## Architectural Guidelines
+
+1. **Contracts live in `@qyou/shared`**:
+   - `packages/shared/src/validation/account-safety.schemas.ts` and
+     `account-safety-phase3.schemas.ts`: payload shapes and rules.
+   - `packages/shared/src/types/account-safety.types.ts`: derived types.
+   - Consumers import through `packages/shared/src/index.ts` only.
+
+2. **Enforcement lives in `apps/api`**:
+   - `apps/api/src/modules/auth/services/account-safety.service.ts`: applies the rules.
+   - `apps/api/src/modules/auth/validators/account-safety-phase3.validator.ts`: the phase-specific
+     validator.
+   - `apps/api/src/modules/auth/repositories/`: the only layer that persists.
+
+3. **`apps/web` consumes, never re-implements**:
+   - `apps/web/src/lib/api-client.ts`: sends payloads typed from the shared contract.
+
+## What Must Not Cross
+
+- **No secrets or hashing in `@qyou/shared`.** The shared package describes *what a valid password
+  looks like*; it never handles, hashes, or compares one. Credential handling stays server side.
+- **No storage adapters in `@qyou/shared`.** Persistence belongs to the API's repository layer.
+- **No dependency from `@qyou/shared` back to `apps/*`.**
+
+## Why This Boundary Is Stricter Here
+
+`@qyou/shared` is consumed by `apps/web` and therefore reachable from the browser bundle. Anything
+placed in it should be assumed to be public. That constraint is what keeps account safety rules
+shareable while the credentials they guard are not.

--- a/docs/account-safety-phase4-e2e-coverage.md
+++ b/docs/account-safety-phase4-e2e-coverage.md
@@ -1,0 +1,38 @@
+# Phase 4 Password, Email & Account Safety — End-to-End Coverage
+
+This document specifies the end-to-end coverage expected for Phase 4 password, email, and account
+safety flows.
+
+## Architectural Guidelines
+
+1. **Schema coverage**:
+   - `packages/shared/src/validation/account-safety.schemas.ts` and
+     `account-safety-phase3.schemas.ts`: passing and failing payloads asserted directly.
+
+2. **Service coverage**:
+   - `apps/api/src/modules/auth/services/account-safety.service.ts` via
+     `apps/api/src/modules/auth/tests/auth.service.test.ts`.
+
+3. **Route coverage**:
+   - `apps/api/src/modules/auth/routes/auth.routes.ts` via
+     `apps/api/src/modules/auth/tests/auth.routes.test.ts`.
+
+## Cases That Must Be Covered
+
+| Case | Assertion |
+|---|---|
+| Happy path | The change applies and is persisted |
+| Rejected payload | Validation fails and **no state is mutated** |
+| Repeated request | Replaying produces no second effect |
+| Cross-phase payload | Valid under an earlier phase, still handled predictably |
+
+## Why the Rejected Path Matters Most
+
+A safety rule that rejects correctly but has already written part of its change is worse than no rule
+at all: the account ends up in a state no code path intended, and the caller was told it failed.
+Asserting "rejected" is not enough — the test must assert **nothing changed**.
+
+## Rule
+
+Phase 4 coverage is complete only when every row above is asserted end to end. Schema-level tests
+alone prove the rule is expressible, not that any caller enforces it.

--- a/docs/shared-auth-contracts-phase4-responsibilities.md
+++ b/docs/shared-auth-contracts-phase4-responsibilities.md
@@ -1,0 +1,36 @@
+# Phase 4 Shared Auth Contracts — Responsibility Split
+
+This document separates the responsibilities for shared auth contracts and schema evolution at
+Phase 4, where multiple phase-specific contracts now coexist.
+
+## Architectural Guidelines
+
+1. **`@qyou/shared` owns contract definition and versioning**:
+   - `packages/shared/src/validation/contract-evolution.schemas.ts` and
+     `token-handling-phase4.schemas.ts`: phase-specific contracts live beside the base
+     `auth.schemas.ts` rather than replacing it.
+   - `packages/shared/src/index.ts`: the single export surface.
+
+2. **`apps/api` owns which contract applies**:
+   - `apps/api/src/modules/auth/validators/contract-evolution.validator.ts` and
+     `token-handling-phase4.validator.ts`: selecting and applying the right phase validator.
+   - The API decides *which* contract a request is evaluated against; `@qyou/shared` only defines
+     what each contract is.
+
+3. **`apps/web` owns none of it**:
+   - `apps/web/src/lib/contract-evolution-client.ts` and `token-handling-phase4-client.ts` consume
+     the contracts. They do not choose between phases on their own.
+
+## The Phase-4 Hazard
+
+With several phase contracts live at once, the real risk is no longer a missing rule — it is **two
+rules disagreeing**. Ownership must stay unambiguous:
+
+- A payload is validated by exactly one phase contract per request.
+- Phase contracts are additive files, never edits to an earlier phase's schema.
+- When phases disagree, the API's selection logic is the tiebreak — not import order.
+
+## Verification
+
+`npm run typecheck` at the root spans every workspace, so a consumer importing a contract the API no
+longer selects fails at compile time rather than silently validating against the wrong phase.

--- a/docs/shared-auth-contracts-phase4-validation.md
+++ b/docs/shared-auth-contracts-phase4-validation.md
@@ -1,0 +1,35 @@
+# Phase 4 Shared Auth Contracts Validation
+
+This document records how validation is tightened for Phase 4 shared auth contracts and schema
+evolution.
+
+## Architectural Guidelines
+
+1. **Phase contracts are additive**:
+   - `packages/shared/src/validation/contract-evolution.schemas.ts` and
+     `token-handling-phase4.schemas.ts`: Phase 4 tightening adds or narrows within these, leaving
+     earlier phase schemas untouched so existing consumers keep validating.
+
+2. **Validators apply them**:
+   - `apps/api/src/modules/auth/validators/contract-evolution.validator.ts` and
+     `token-handling-phase4.validator.ts`: the enforcement point. Rules live in the schema; the
+     validator decides when to run it.
+
+3. **Client parity**:
+   - `apps/web/src/lib/contract-evolution-client.ts` and `token-handling-phase4-client.ts` use the
+     shared types, so a tightened field breaks the build rather than a user's request.
+
+## Validation Rules
+
+- **Narrow in the schema, not the validator.** A check added only in a validator is invisible to
+  every other consumer and to typecheck.
+- **A tightened field must be typechecked across the workspace** before merge, since consumers
+  compile against the shared build.
+- **Unknown fields are rejected, not ignored.** Silently dropping an unrecognised field hides the
+  fact that a client is sending against the wrong phase contract.
+
+## Test Expectations
+
+- `apps/api/src/modules/auth/tests/auth.service.test.ts`: service behaviour per phase contract.
+- `apps/api/src/modules/auth/tests/auth.routes.test.ts`: the same payloads through the route,
+  including one that is valid under an earlier phase but invalid under Phase 4.


### PR DESCRIPTION
Adds 4 documents for the sprint-2 **Auth and Identity Flows** theme.

Closes #685
Closes #688
Closes #691
Closes #692

## Files added

| Path |
|---|
| `docs/account-safety-phase4-boundary.md` |
| `docs/account-safety-phase4-e2e-coverage.md` |
| `docs/shared-auth-contracts-phase4-responsibilities.md` |
| `docs/shared-auth-contracts-phase4-validation.md` |

## Notes

- **Documentation only.** No application code changes, so nothing in `apps/api`, `apps/web`, or `packages/shared` is touched.
- Follows the existing `docs/` convention for this sprint (`<focus>-phase<N>-<action>.md`, `## Architectural Guidelines` section), matching files such as `session-lifecycle-phase4-validation.md` and `shared-auth-contracts-phase4.md`.
- Every file is under 50 lines, and all referenced paths point at modules that exist on `main` today.
- All filenames are new — nothing existing in `docs/` is modified or renamed.
- Branched from `d7c546f` (current upstream `main`), so the PR merges cleanly.