### PR TITLE
docs(auth): sprint-2 auth and identity flow docs for #676, #679, #680, #684

### DIFF
--- a/docs/registration-login-hardening-phase4-boundary.md
+++ b/docs/registration-login-hardening-phase4-boundary.md
@@ -1,0 +1,38 @@
+# Phase 4 Registration & Login Hardening — Package Boundary
+
+This document defines the package boundary for Phase 4 registration and login hardening.
+
+## Architectural Guidelines
+
+1. **Contracts in `@qyou/shared`**:
+   - `packages/shared/src/validation/login-hardening.schemas.ts` and
+     `login-security.schemas.ts`: registration and login payload shapes and constraints.
+   - `packages/shared/src/types/login-hardening.types.ts`: the derived types.
+   - Consumed through `packages/shared/src/index.ts` only.
+
+2. **Enforcement in `apps/api`**:
+   - `apps/api/src/modules/auth/validators/login-hardening.validator.ts` and
+     `login-security.validator.ts`: apply the hardening rules.
+   - `apps/api/src/modules/auth/services/auth.service.ts`: owns the decision to accept or reject.
+
+3. **Consumption in `apps/web`**:
+   - `apps/web/src/lib/api-client.ts`: sends payloads typed from the shared contract.
+
+## What Must Not Cross
+
+- **No rate-limit or lockout state in `@qyou/shared`.** Hardening counters are server-side state; a
+  browser-visible copy is advisory at best and an attacker's roadmap at worst.
+- **No credential handling in `@qyou/shared`.** The package defines what a valid credential *looks
+  like*, never how one is stored or compared.
+- **No dependency from `@qyou/shared` back to `apps/*`.**
+
+## The Asymmetry Worth Naming
+
+Hardening rules are deliberately split: the *shape* rules are shared so the form and the API agree,
+but the *defensive* rules — attempt limits, backoff, lockout — stay entirely in the API. Sharing the
+first improves UX; sharing the second would publish the thresholds an attacker needs to stay under.
+
+## Verification
+
+`npm run typecheck` at the root covers every workspace, so a boundary violation surfaces at compile
+time.

--- a/docs/registration-login-hardening-phase4-rollout.md
+++ b/docs/registration-login-hardening-phase4-rollout.md
@@ -1,0 +1,38 @@
+# Phase 4 Registration & Login Hardening Rollout
+
+This document sets out the rollout plan for Phase 4 registration and login hardening.
+
+## Architectural Guidelines
+
+1. **Shared contracts first**:
+   - `packages/shared/src/validation/login-hardening.schemas.ts` and `login-security.schemas.ts`
+     ship ahead of consumers; the root build compiles `@qyou/shared` before the apps.
+
+2. **API next, in report-only mode**:
+   - `apps/api/src/modules/auth/validators/login-hardening.validator.ts` and
+     `login-security.validator.ts`: evaluate the new rules and record outcomes **before** they begin
+     rejecting traffic.
+
+3. **Web last**:
+   - `apps/web/src/lib/api-client.ts` and `auth-context.tsx`: updated to surface the new rejection
+     reasons once enforcement is on.
+
+## Rollout Sequence
+
+1. Merge shared schemas; confirm `@qyou/shared` builds.
+2. Deploy the API **evaluating but not enforcing**; observe how much real traffic the new rules would
+   have rejected.
+3. Turn on enforcement once that number is understood.
+4. Deploy the web app to render the new rejection reasons clearly.
+
+## Why Step 2 Is Not Optional
+
+Hardening rules reject real users, not just attackers. A password or attempt-limit rule that looks
+reasonable can lock out a meaningful share of legitimate sign-ins, and enforcement-first deployment
+discovers this from support tickets rather than from data. Report-only makes the blast radius
+measurable while it is still reversible.
+
+## Rollback
+
+Steps 1–2 are inert and safe to revert. Step 3 is the behaviour change: keep it a separate,
+independently revertible deploy so enforcement can be switched off without reverting the contracts.

--- a/docs/session-lifecycle-phase4-responsibilities.md
+++ b/docs/session-lifecycle-phase4-responsibilities.md
@@ -1,0 +1,36 @@
+# Phase 4 Session Lifecycle & Token Handling — Responsibility Split
+
+This document separates the responsibilities for session lifecycle and token handling at Phase 4,
+where proactive client-side refresh is in play.
+
+## Architectural Guidelines
+
+1. **`@qyou/shared` owns the shape**:
+   - `packages/shared/src/validation/token-handling-phase4.schemas.ts` and
+     `packages/shared/src/types/token-handling-phase4.types.ts`: what a token and its lifetime
+     fields are. No policy.
+
+2. **`apps/api` owns authority**:
+   - `apps/api/src/modules/auth/validators/token-handling-phase4.validator.ts`:
+     `evaluatePhase4TokenState` evaluates expiry and active renewal windows.
+   - `apps/api/src/modules/auth/services/auth.service.ts`: issues, refreshes, revokes.
+
+3. **`apps/web` owns timing, not truth**:
+   - `apps/web/src/lib/token-handling-phase4-client.ts`: inspects token lifetime to decide whether a
+     proactive renewal is worth making.
+
+## The Distinction Phase 4 Depends On
+
+The client now decides **when to ask** for a refresh. It still does not decide **whether the session
+is valid**. Those two look similar and are not:
+
+- *When to ask* is an optimisation. Getting it wrong costs an extra request or a brief stall.
+- *Whether it is valid* is authorisation. Getting it wrong is a security bug.
+
+`token-handling-phase4-client.ts` may therefore read expiry locally to schedule work, but a token the
+client believes is fine is still rejected if the API disagrees.
+
+## Consequence
+
+Revocation continues to work under proactive refresh: the server clearing its state ends the session
+on the next call, no matter what the client's local inspection concluded.

--- a/docs/session-lifecycle-phase4-rollout.md
+++ b/docs/session-lifecycle-phase4-rollout.md
@@ -1,0 +1,37 @@
+# Phase 4 Session Lifecycle & Token Handling Rollout
+
+This document sets out the rollout plan for Phase 4 session lifecycle and token handling, which adds
+proactive client-side token renewal.
+
+## Architectural Guidelines
+
+1. **Shared contracts first**:
+   - `packages/shared/src/validation/token-handling-phase4.schemas.ts` and
+     `packages/shared/src/types/token-handling-phase4.types.ts` ship ahead of consumers.
+
+2. **API next**:
+   - `apps/api/src/modules/auth/validators/token-handling-phase4.validator.ts`: must accept refresh
+     requests from clients that renew *early* before any client starts doing so.
+
+3. **Web last**:
+   - `apps/web/src/lib/token-handling-phase4-client.ts`: begins proactive renewal only once the API
+     accepts it.
+
+## Rollout Sequence
+
+1. Merge shared schemas; confirm `@qyou/shared` builds.
+2. Deploy the API accepting both reactive (on-expiry) and proactive (early) refresh.
+3. Deploy the web app with proactive renewal enabled.
+4. Retire the reactive-only path once clients have updated.
+
+## The Ordering Constraint
+
+Steps 2 and 3 cannot be swapped or bundled. A client that renews early against an API that only
+accepts refresh at expiry gets its request rejected — and because renewal runs on a timer rather than
+on user action, the failure appears as unexplained sign-outs rather than a failed click.
+
+## Rollback
+
+Steps 1–3 revert independently while step 2 accepts both refresh styles. Step 4 removes that
+tolerance, so run it as its own deployment once client traffic confirms nobody relies on the old
+path.


### PR DESCRIPTION
Adds 4 documents for the sprint-2 **Auth and Identity Flows** theme.

Closes #676
Closes #679
Closes #680
Closes #684

## Files added

| Path |
|---|
| `docs/registration-login-hardening-phase4-boundary.md` |
| `docs/registration-login-hardening-phase4-rollout.md` |
| `docs/session-lifecycle-phase4-responsibilities.md` |
| `docs/session-lifecycle-phase4-rollout.md` |

## Notes

- **Documentation only.** No application code changes, so nothing in `apps/api`, `apps/web`, or `packages/shared` is touched.
- Follows the existing `docs/` convention for this sprint (`<focus>-phase<N>-<action>.md`, `## Architectural Guidelines` section), matching files such as `session-lifecycle-phase4-validation.md` and `shared-auth-contracts-phase4.md`.
- Every file is under 50 lines, and all referenced paths point at modules that exist on `main` today.
- All filenames are new — nothing existing in `docs/` is modified or renamed.
- Branched from `d7c546f` (current upstream `main`), so the PR merges cleanly.